### PR TITLE
Bump version from 0.11.2 to 0.12-dev

### DIFF
--- a/tsuru/main.go
+++ b/tsuru/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "0.11.2"
+	version = "0.12-dev"
 	header  = "Supported-Tsuru"
 )
 


### PR DESCRIPTION
to make it clear that this is not 0.11.2 and it's a dev build by default.

Having it show 0.11.2 causes confusion like what I had in https://github.com/tsuru/tsuru/issues/920

Cc: @fsouza 
