### PR TITLE
Add --output-format option to app-info command

### DIFF
--- a/tsuru/apps.go
+++ b/tsuru/apps.go
@@ -143,6 +143,8 @@ func (c *appRemove) Flags() *gnuflag.FlagSet {
 
 type appInfo struct {
 	cmd.GuessingCommand
+	outputFormat string
+	fs           *gnuflag.FlagSet
 }
 
 func (c *appInfo) Info() *cmd.Info {
@@ -154,6 +156,20 @@ func (c *appInfo) Info() *cmd.Info {
 If you don't provide the app name, tsuru will try to guess it.`,
 		MinArgs: 0,
 	}
+}
+
+func (c *appInfo) Flags() *gnuflag.FlagSet {
+	if c.fs == nil {
+		fs := gnuflag.NewFlagSet("", gnuflag.ExitOnError)
+		outputFormatMessage := "Output to format (e.g.: \"normal\", \"json\", \"prettyjson\")"
+		fs.StringVar(&c.outputFormat, "output-format", "", outputFormatMessage)
+
+		c.fs = cmd.MergeFlagSet(
+			c.GuessingCommand.Flags(),
+			fs,
+		)
+	}
+	return c.fs
 }
 
 func (c *appInfo) Run(context *cmd.Context, client *cmd.Client) error {
@@ -215,7 +231,7 @@ func (c *appInfo) Run(context *cmd.Context, client *cmd.Client) error {
 			return err
 		}
 	}
-	return c.Show(result, adminResult, servicesResult, context)
+	return c.Show(result, adminResult, servicesResult, context, c.outputFormat)
 }
 
 type unit struct {
@@ -343,7 +359,7 @@ Deploys: {{.Deploys}}
 	return buf.String() + suffix
 }
 
-func (c *appInfo) Show(result []byte, adminResult []byte, servicesResult []byte, context *cmd.Context) error {
+func (c *appInfo) Show(result []byte, adminResult []byte, servicesResult []byte, context *cmd.Context, format string) error {
 	var a app
 	err := json.Unmarshal(result, &a)
 	if err != nil {
@@ -351,7 +367,21 @@ func (c *appInfo) Show(result []byte, adminResult []byte, servicesResult []byte,
 	}
 	json.Unmarshal(adminResult, &a.containers)
 	json.Unmarshal(servicesResult, &a.services)
-	fmt.Fprintln(context.Stdout, &a)
+
+	if strings.ToLower(format) == "prettyjson" {
+		// Pretty-printed (indented) json
+		out, err := json.MarshalIndent(a, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(context.Stdout, "%s\n", out)
+	} else if strings.ToLower(format) == "json" {
+		fmt.Fprintln(context.Stdout, string(result))
+	} else {
+		// Normal, human-readable
+		fmt.Fprintln(context.Stdout, &a)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This adds an `--output-format` option to the `app-info` command. The main purpose of this is to output the information in JSON for easier consumption by other software.

This is an alternative to https://github.com/tsuru/tsuru-client/pull/2, which adds the ability to print single fields.

E.g.:

    $ tsuru app-info --help
    Usage of :
    -a, --app (= "")
        The name of the app.
    --output-format (= "")
        Output to format (e.g.: "normal", "json", "prettyjson")

    $ tsuru app-info --output-format=json
    {"cname":[],"deploys":1,"ip":"tsuru-dashboard.10.128.40.70.xip.io",
     "name":"tsuru-dashboard","owner":"marca@mycompany.com",
     "plan":{"name":"autogenerated","memory":0,"swap":0,"cpushare":100},
     "platform":"python","ready":true,
     "repository":"git@tsuru.corp.mycompany.com:tsuru-dashboard.git",
     "teamowner":"admin","teams":["admin","devops"],
     "units":[{"Name":"d0a8595dd4ebbc15558e04fe33a74c9cc462e5551c03981d91a0006ce33f1962",
     "AppName":"tsuru-dashboard","Type":"python","Ip":"10.128.40.73",
     "Status":"started"}]}

    $ tsuru app-info --output-format=prettyjson
    {
        "Ip": "tsuru-dashboard.10.128.40.70.xip.io",
        "CName": [],
        "Name": "tsuru-dashboard",
        "Platform": "python",
        "Repository": "git@tsuru.corp.mycompany.com:tsuru-dashboard.git",
        "Teams": [
            "admin",
            "devops"
        ],
        "Units": [
            {
                "Name":
    "d0a8595dd4ebbc15558e04fe33a74c9cc462e5551c03981d91a0006ce33f1962",
                "Ip": "10.128.40.73",
                "Status": "started"
            }
        ],
        "Ready": true,
        "Owner": "marca@mycompany.com",
        "TeamOwner": "admin",
        "Deploys": 1
    }

Cc: @fsouza, @jblancett