### PR TITLE
deploy => app-deploy in app-deploy examples

### DIFF
--- a/tsuru/deploy.go
+++ b/tsuru/deploy.go
@@ -28,8 +28,8 @@ type appDeploy struct {
 func (c *appDeploy) Info() *cmd.Info {
 	desc := `Deploys set of files and/or directories to tsuru server. Some examples of calls are:
 
-tsuru deploy .
-tsuru deploy myfile.jar Procfile
+tsuru app-deploy .
+tsuru app-deploy myfile.jar Procfile
 `
 	return &cmd.Info{
 		Name:    "app-deploy",

--- a/tsuru/deploy_test.go
+++ b/tsuru/deploy_test.go
@@ -21,8 +21,8 @@ import (
 func (s *S) TestDeployInfo(c *gocheck.C) {
 	desc := `Deploys set of files and/or directories to tsuru server. Some examples of calls are:
 
-tsuru deploy .
-tsuru deploy myfile.jar Procfile
+tsuru app-deploy .
+tsuru app-deploy myfile.jar Procfile
 `
 	expected := &cmd.Info{
 		Name:    "app-deploy",


### PR DESCRIPTION
```
$ tsuru app-deploy
tsuru version 0.13.2.

ERROR: wrong number of arguments.

Usage: tsuru app-deploy [-a/--app <appname>] <file-or-dir-1> [file-or-dir-2] ... [file-or-dir-n]

Deploys set of files and/or directories to tsuru server. Some examples of calls are:

tsuru app-deploy .
tsuru app-deploy myfile.jar Procfile


Minimum # of arguments: 1
```
