### PR TITLE
auth: Keep .tsuru-token on user-remove

### DIFF
--- a/tsuru/auth.go
+++ b/tsuru/auth.go
@@ -126,7 +126,6 @@ func (c *userRemove) Run(context *cmd.Context, client *cmd.Client) error {
 	if err != nil {
 		return err
 	}
-	filesystem().Remove(cmd.JoinWithUserDir(".tsuru_token"))
 	fmt.Fprintf(context.Stdout, "User %q successfully removed.\n", email)
 	return nil
 }

--- a/tsuru/auth_test.go
+++ b/tsuru/auth_test.go
@@ -379,7 +379,6 @@ func (s *S) TestUserRemove(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(called, check.Equals, true)
 	c.Assert(buf.String(), check.Equals, "Are you sure you want to remove the user \"myuser@tsuru.io\" from tsuru? (y/n) User \"myuser@tsuru.io\" successfully removed.\n")
-	c.Assert(rfs.HasAction("remove "+cmd.JoinWithUserDir(".tsuru_token")), check.Equals, true)
 }
 
 func (s *S) TestUserRemoveWithArgs(c *check.C) {
@@ -413,7 +412,6 @@ func (s *S) TestUserRemoveWithArgs(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(called, check.Equals, true)
 	c.Assert(buf.String(), check.Equals, "Are you sure you want to remove the user \"u@email.com\" from tsuru? (y/n) User \"u@email.com\" successfully removed.\n")
-	c.Assert(rfs.HasAction("remove "+cmd.JoinWithUserDir(".tsuru_token")), check.Equals, true)
 }
 
 func (s *S) TestUserRemoveWithoutConfirmation(c *check.C) {


### PR DESCRIPTION
Don't delete `~/.tsuru-token` when deleting a user with `user-remove`. So
that an administrator deleting other users doesn't have to re-login after
each command.

I did think about retaining the existing behaviour for the "without args"
case where you are deleting yourself. However it ever so slightly increased
the code complexity and the test may have produced false-negatives in the
future, which didn't seem worth it when the user's token would be
invalidated and they'd be prompted to login the next time anyway.

Fixes tsuru/tsuru#1235