### PR TITLE
Manpages are now generated by Sphinx. Removing old target rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,6 @@ doc: docs-clean docs-requirements
 
 docs: doc
 
-manpage: docs docs/source/exts/man_pages.py
-	$(PYTHON) $(word 2, $^)
-
 test:
 	go test ./... -check.vv
 


### PR DESCRIPTION
This Pull request removes a Makefile target rule that is no longer used