### PR TITLE
fix tsuru issue #1442 - token-show and user-remove commands correct passing email argument

### DIFF
--- a/tsuru/client/auth.go
+++ b/tsuru/client/auth.go
@@ -119,7 +119,7 @@ func (c *UserRemove) Run(context *cmd.Context, client *cmd.Client) error {
 	}
 	var qs string
 	if email != "" {
-		qs = "?user=" + email
+		qs = "?user=" + url.QueryEscape(email)
 	}
 	request, err := http.NewRequest("DELETE", u+qs, nil)
 	if err != nil {
@@ -400,14 +400,14 @@ if you need to invalidate an existing token.`,
 }
 
 func (c *ShowAPIToken) Run(context *cmd.Context, client *cmd.Client) error {
-	url, err := cmd.GetURL("/users/api-key")
+	u, err := cmd.GetURL("/users/api-key")
 	if err != nil {
 		return err
 	}
 	if c.user != "" {
-		url += fmt.Sprintf("?user=%s", c.user)
+		u += fmt.Sprintf("?user=%s", url.QueryEscape(c.user))
 	}
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return err
 	}

--- a/tsuru/client/auth_test.go
+++ b/tsuru/client/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"gopkg.in/check.v1"
@@ -364,7 +365,7 @@ func (s *S) TestUserRemoveWithArgs(c *check.C) {
 	context := cmd.Context{
 		Stdout: &buf,
 		Stdin:  strings.NewReader("y\n"),
-		Args:   []string{"u@email.com"},
+		Args:   []string{"test+u@email.com"},
 	}
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "", Status: http.StatusOK},
@@ -378,7 +379,7 @@ func (s *S) TestUserRemoveWithArgs(c *check.C) {
 	err := command.Run(&context, client)
 	c.Assert(err, check.IsNil)
 	c.Assert(called, check.Equals, true)
-	c.Assert(buf.String(), check.Equals, "Are you sure you want to remove the user \"u@email.com\" from tsuru? (y/n) User \"u@email.com\" successfully removed.\n")
+	c.Assert(buf.String(), check.Equals, "Are you sure you want to remove the user \"test+u@email.com\" from tsuru? (y/n) User \"test+u@email.com\" successfully removed.\n")
 }
 
 func (s *S) TestUserRemoveWithoutConfirmation(c *check.C) {
@@ -602,7 +603,7 @@ func (s *S) TestShowAPITokenRunWithFlag(c *check.C) {
 		CondFunc: func(req *http.Request) bool {
 			called = true
 			return req.Method == "GET" && strings.HasSuffix(req.URL.Path, "/users/api-key") &&
-				req.URL.RawQuery == "user=admin@example.com"
+				req.URL.RawQuery == "user="+url.QueryEscape("admin@example.com")
 		},
 	}
 	expected := `API key: 23iou32nd3i2udnu23jd


### PR DESCRIPTION
When you execute 'tsuru token-show -u test+testing@example.com' the email argument wasn't encoded correctly as a query string parameter to the tsuru server.

As a result the tsuru server was getting "test testing@example.com" as the email value on this case.

Fixed that query string encoding on "token-show" and "user-remove" commands with this PR.
I also updated a "user-remove" test to show the problem (without these changes to auth.go, this updated test would fail).

This problem was introduced on: https://github.com/tsuru/tsuru/issues/1442 and it wasn't a problem in the email validation function itself, like i said on this PR to tsuru: https://github.com/tsuru/tsuru/pull/1461