### PR TITLE
Updates admin command helpers

### DIFF
--- a/tsuru/admin/platform.go
+++ b/tsuru/admin/platform.go
@@ -91,10 +91,10 @@ official platforms and instructions on how to create a custom platform.
 
 Examples:
 
-	[[tsuru-admin platform-add java # uses official tsuru/java image from docker hub]]
-	[[tsuru-admin platform-add java -i registry.company.com/tsuru/java # uses custom Java image]]
-	[[tsuru-admin platform-add java -d /data/projects/java/Dockerfile # uses local Dockerfile]]
-	[[tsuru-admin platform-add java -d https://platforms.com/java/Dockerfile # uses remote Dockerfile]]`,
+	[[tsuru platform-add java # uses official tsuru/java image from docker hub]]
+	[[tsuru platform-add java -i registry.company.com/tsuru/java # uses custom Java image]]
+	[[tsuru platform-add java -d /data/projects/java/Dockerfile # uses local Dockerfile]]
+	[[tsuru platform-add java -d https://platforms.com/java/Dockerfile # uses remote Dockerfile]]`,
 		MinArgs: 1,
 	}
 }
@@ -160,10 +160,10 @@ platform.
 
 Examples:
 
-[[tsuru-admin platform-update java # uses official tsuru/java image from docker hub]]
-[[tsuru-admin platform-update java -i registry.company.com/tsuru/java # uses custom Java image]]
-[[tsuru-admin platform-update java -d /data/projects/java/Dockerfile # uses local Dockerfile]]
-[[tsuru-admin platform-update java -d https://platforms.com/java/Dockerfile # uses remote Dockerfile]]`,
+[[tsuru platform-update java # uses official tsuru/java image from docker hub]]
+[[tsuru platform-update java -i registry.company.com/tsuru/java # uses custom Java image]]
+[[tsuru platform-update java -d /data/projects/java/Dockerfile # uses local Dockerfile]]
+[[tsuru platform-update java -d https://platforms.com/java/Dockerfile # uses remote Dockerfile]]`,
 		MinArgs: 1,
 	}
 }

--- a/tsuru/admin/pool.go
+++ b/tsuru/admin/pool.go
@@ -30,7 +30,7 @@ func (AddPoolToSchedulerCmd) Info() *cmd.Info {
 		Usage: "pool-add <pool> [-p/--public] [-d/--default] [--provisioner <name>] [-f/--force]",
 		Desc: `Adds a new pool.
 
-Each docker node added using [[docker-node-add]] command belongs to one pool.
+Each docker node added using [[node-add]] command belongs to one pool.
 Also, when creating a new application a pool must be chosen and this means
 that all units of the created application will be spawned in nodes belonging
 to the chosen pool.`,


### PR DESCRIPTION
This PR update admin commands to use tsuru instead of tsuru-admin in command helpers.

Also to use ```node-add``` instead of ```docker-node-add```