### PR TITLE
Add -p to mkdir

### DIFF
--- a/tsuru/installer/dm/dockermachine.go
+++ b/tsuru/installer/dm/dockermachine.go
@@ -155,7 +155,7 @@ func (d *DockerMachine) uploadRegistryCertificate(ip, user string, target sshTar
 		return err
 	}
 	dockerCertsPath := "/etc/docker/certs.d"
-	if _, err := target.RunSSHCommand(fmt.Sprintf("sudo mkdir %s", dockerCertsPath)); err != nil {
+	if _, err := target.RunSSHCommand(fmt.Sprintf("sudo mkdir -p %s", dockerCertsPath)); err != nil {
 		return err
 	}
 	fileCopies := map[string]string{

--- a/tsuru/installer/dm/dockermachine_test.go
+++ b/tsuru/installer/dm/dockermachine_test.go
@@ -47,7 +47,7 @@ func (s *S) TestUploadRegistryCertificate(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(len(sshTarget.cmds), check.Equals, 11)
 	c.Assert(sshTarget.cmds[0], check.Equals, "mkdir -p /home/ubuntu/certs/127.0.0.1:5000")
-	c.Assert(sshTarget.cmds[1], check.Equals, "sudo mkdir /etc/docker/certs.d")
+	c.Assert(sshTarget.cmds[1], check.Equals, "sudo mkdir -p /etc/docker/certs.d")
 	s.containsWithSubstring(sshTarget.cmds, "sudo tee /etc/docker/certs.d/ca-key.pem", c)
 	s.containsWithSubstring(sshTarget.cmds, "sudo tee /etc/docker/certs.d/ca.pem", c)
 	s.containsWithSubstring(sshTarget.cmds, "sudo tee /etc/docker/certs.d/cert.pem", c)
@@ -60,7 +60,7 @@ func (s *S) TestUploadRegistryCertificate(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(len(sshTarget2.cmds), check.Equals, 11)
 	c.Assert(sshTarget2.cmds[0], check.Equals, "mkdir -p /home/ubuntu/certs/127.0.0.1:5000")
-	c.Assert(sshTarget2.cmds[1], check.Equals, "sudo mkdir /etc/docker/certs.d")
+	c.Assert(sshTarget2.cmds[1], check.Equals, "sudo mkdir -p /etc/docker/certs.d")
 	s.containsWithSubstring(sshTarget2.cmds, "sudo tee /home/ubuntu/certs/127.0.0.1:5000/registry-cert.pem", c)
 	s.containsWithSubstring(sshTarget2.cmds, "sudo tee /home/ubuntu/certs/127.0.0.1:5000/registry-key.pem", c)
 }


### PR DESCRIPTION
Fix the following issue:

```
Uploading registry certificate...
Error: failed to provision components machines: failed to provision machines: error uploading registry certificates to 1.2.3.4: Something went wrong running an SSH command!
command : sudo mkdir /etc/docker/certs.d && sudo cp -r /home/docker-user/certs/* /etc/docker/certs.d/
err     : exit status 1
output  : mkdir: cannot create directory ‘/etc/docker/certs.d’: File exists
```