### PR TITLE
Force eth0 as internal interface for Google Cloud

### DIFF
--- a/tsuru/installer/dm/drivers.go
+++ b/tsuru/installer/dm/drivers.go
@@ -28,6 +28,8 @@ func GetPrivateIPInterface(driverName string) (string, error) {
 	switch driverName {
 	case "amazonec2":
 		return "eth0", nil
+	case "google":
+		return "eth0", nil
 	default:
 		return "", ErrNoPrivateIPInterface
 	}

--- a/tsuru/installer/dm/drivers_test.go
+++ b/tsuru/installer/dm/drivers_test.go
@@ -37,8 +37,14 @@ func (s *S) TestGetPrivateIPInterfaceFromConfig(c *check.C) {
 	c.Assert(iface, check.Equals, "eth1")
 }
 
-func (s *S) TestGetPrivateIPInterfaceForDriver(c *check.C) {
+func (s *S) TestGetPrivateIPInterfaceForAmazonEC2Driver(c *check.C) {
 	iface, err := GetPrivateIPInterface("amazonec2")
+	c.Assert(err, check.IsNil)
+	c.Assert(iface, check.Equals, "eth0")
+}
+
+func (s *S) TestGetPrivateIPInterfaceForGoogleDriver(c *check.C) {
+	iface, err := GetPrivateIPInterface("google")
 	c.Assert(err, check.IsNil)
 	c.Assert(iface, check.Equals, "eth0")
 }


### PR DESCRIPTION
When using Google Cloud as driver for docker-machine, like with Amazon EC2, eth0 is the internal interface and must be forced to avoid some errors during the install

Fix https://github.com/tsuru/tsuru/issues/1505