### PR TITLE
client: improve error handling in pool-list

### DIFF
--- a/tsuru/client/pool.go
+++ b/tsuru/client/pool.go
@@ -65,6 +65,11 @@ func (PoolList) Run(context *cmd.Context, client *cmd.Client) error {
 	if err != nil {
 		return err
 	}
+	t := cmd.Table{Headers: cmd.Row([]string{"Pool", "Kind", "Provisioner", "Teams", "Routers"})}
+	if resp.StatusCode == http.StatusNoContent {
+		context.Stdout.Write(t.Bytes())
+		return nil
+	}
 	defer resp.Body.Close()
 	var pools []Pool
 	err = json.NewDecoder(resp.Body).Decode(&pools)
@@ -72,7 +77,6 @@ func (PoolList) Run(context *cmd.Context, client *cmd.Client) error {
 		return err
 	}
 	sort.Sort(poolEntriesList(pools))
-	t := cmd.Table{Headers: cmd.Row([]string{"Pool", "Kind", "Provisioner", "Teams", "Routers"})}
 	for _, pool := range pools {
 		teams := strings.Join(pool.Allowed["team"], ", ")
 		routers := strings.Join(pool.Allowed["router"], ", ")

--- a/tsuru/client/pool_test.go
+++ b/tsuru/client/pool_test.go
@@ -41,3 +41,18 @@ func (s *S) TestPoolListRun(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(stdout.String(), check.Equals, expected)
 }
+
+func (s *S) TestPoolListRunNoContent(c *check.C) {
+	var stdout bytes.Buffer
+	context := cmd.Context{Args: []string{}, Stdout: &stdout}
+	client := cmd.NewClient(&http.Client{Transport: &cmdtest.Transport{Status: http.StatusNoContent}}, nil, manager)
+	command := PoolList{}
+	err := command.Run(&context, client)
+	expected := `+------+------+-------------+-------+---------+
+| Pool | Kind | Provisioner | Teams | Routers |
++------+------+-------------+-------+---------+
++------+------+-------------+-------+---------+
+`
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout.String(), check.Equals, expected)
+}


### PR DESCRIPTION
With empty pool-list

Before:
```
$ tsuru pool-list
Error: EOF
```

After:
```
$ tsuru pool-list
+------+------+-------------+-------+---------+
| Pool | Kind | Provisioner | Teams | Routers |
+------+------+-------------+-------+---------+
+------+------+-------------+-------+---------+
```
