### PR TITLE
app-deploy with directory

### DIFF
--- a/tsuru/client/deploy.go
+++ b/tsuru/client/deploy.go
@@ -122,10 +122,10 @@ func (c *AppDeployList) Run(context *cmd.Context, client *cmd.Client) error {
 
 type AppDeploy struct {
 	cmd.GuessingCommand
-	image    string
-	message  string
-	rootFile bool
-	fs       *gnuflag.FlagSet
+	image     string
+	message   string
+	filesOnly bool
+	fs        *gnuflag.FlagSet
 }
 
 func (c *AppDeploy) Flags() *gnuflag.FlagSet {
@@ -137,9 +137,9 @@ func (c *AppDeploy) Flags() *gnuflag.FlagSet {
 		message := "A message describing this deploy"
 		c.fs.StringVar(&c.message, "message", "", message)
 		c.fs.StringVar(&c.message, "m", "", message)
-		rf := "Enables single file deployment into the root of the app's tree"
-		c.fs.BoolVar(&c.rootFile, "r", false, rf)
-		c.fs.BoolVar(&c.rootFile, "root-file", false, rf)
+		filesOnly := "Enables single file deployment into the root of the app's tree"
+		c.fs.BoolVar(&c.filesOnly, "f", false, filesOnly)
+		c.fs.BoolVar(&c.filesOnly, "files-only", false, filesOnly)
 	}
 	return c.fs
 }
@@ -152,12 +152,13 @@ calls are:
 
     $ tsuru app-deploy .
     $ tsuru app-deploy myfile.jar Procfile
+    $ tsuru app-deploy -f directory/main.go directory/Procfile
     $ tsuru app-deploy mysite
     $ tsuru app-deploy -i http://registry.mysite.com:5000/image-name
 `
 	return &cmd.Info{
 		Name:    "app-deploy",
-		Usage:   "app-deploy [-a/--app <appname>] [-i/--image <image_url>] [-m/--message <message>] [-r/--root-file] <file-or-dir-1> [file-or-dir-2] ... [file-or-dir-n]",
+		Usage:   "app-deploy [-a/--app <appname>] [-i/--image <image_url>] [-m/--message <message>] [-f/--files-only] <file-or-dir-1> [file-or-dir-2] ... [file-or-dir-n]",
 		Desc:    desc,
 		MinArgs: 0,
 	}
@@ -249,7 +250,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 				ignoreSet[k] = v
 			}
 		}
-		err = targz(context, file, ignoreSet, c.rootFile, context.Args...)
+		err = targz(context, file, ignoreSet, c.filesOnly, context.Args...)
 		if err != nil {
 			return err
 		}
@@ -368,7 +369,7 @@ func readTsuruIgnore() ([]string, error) {
 	return patterns, nil
 }
 
-func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{}, rootFile bool, filepaths ...string) error {
+func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{}, filesOnly bool, filepaths ...string) error {
 	var buf bytes.Buffer
 	tarWriter := tar.NewWriter(&buf)
 	for _, path := range filepaths {
@@ -393,8 +394,8 @@ func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{
 				return singleDir(ctx, destination, path, ignoreSet)
 			}
 			err = addDir(tarWriter, path, ignoreSet)
-		} else if rootFile {
-			err = singleFile(tarWriter, path)
+		} else if filesOnly {
+			err = addFileOnly(tarWriter, path)
 		} else {
 			err = addFile(tarWriter, path)
 		}
@@ -472,7 +473,7 @@ func addDir(writer *tar.Writer, dirpath string, ignoreSet map[string]struct{}) e
 	return nil
 }
 
-func singleFile(writer *tar.Writer, filepath string) error {
+func addFileOnly(writer *tar.Writer, filepath string) error {
 	f, err := os.Open(filepath)
 	if err != nil {
 		return err

--- a/tsuru/client/deploy.go
+++ b/tsuru/client/deploy.go
@@ -122,9 +122,10 @@ func (c *AppDeployList) Run(context *cmd.Context, client *cmd.Client) error {
 
 type AppDeploy struct {
 	cmd.GuessingCommand
-	image   string
-	message string
-	fs      *gnuflag.FlagSet
+	image       string
+	message     string
+	singleFiles bool
+	fs          *gnuflag.FlagSet
 }
 
 func (c *AppDeploy) Flags() *gnuflag.FlagSet {
@@ -136,6 +137,9 @@ func (c *AppDeploy) Flags() *gnuflag.FlagSet {
 		message := "A message describing this deploy"
 		c.fs.StringVar(&c.message, "message", "", message)
 		c.fs.StringVar(&c.message, "m", "", message)
+		sf := "enables single file deployment"
+		c.fs.BoolVar(&c.singleFiles, "s", false, sf)
+		c.fs.BoolVar(&c.singleFiles, "single-files", false, sf)
 	}
 	return c.fs
 }
@@ -245,7 +249,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 				ignoreSet[k] = v
 			}
 		}
-		err = targz(context, file, ignoreSet, context.Args...)
+		err = targz(context, file, ignoreSet, c.singleFiles, context.Args...)
 		if err != nil {
 			return err
 		}
@@ -277,6 +281,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 			}
 		}()
 	}
+	// fmt.Println(c.singleFiles)
 	resp, err := client.Do(request)
 	if err != nil {
 		return err
@@ -364,7 +369,7 @@ func readTsuruIgnore() ([]string, error) {
 	return patterns, nil
 }
 
-func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{}, filepaths ...string) error {
+func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{}, singleFiles bool, filepaths ...string) error {
 	var buf bytes.Buffer
 	tarWriter := tar.NewWriter(&buf)
 	for _, path := range filepaths {
@@ -389,6 +394,8 @@ func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{
 				return singleDir(ctx, destination, path, ignoreSet)
 			}
 			err = addDir(tarWriter, path, ignoreSet)
+		} else if singleFiles {
+			err = singleFile(tarWriter, path)
 		} else {
 			err = addFile(tarWriter, path)
 		}
@@ -416,7 +423,7 @@ func singleDir(ctx *cmd.Context, destination io.Writer, path string, ignoreSet m
 	if err != nil {
 		return err
 	}
-	return targz(ctx, destination, ignoreSet, ".")
+	return targz(ctx, destination, ignoreSet, false, ".")
 }
 
 func addDir(writer *tar.Writer, dirpath string, ignoreSet map[string]struct{}) error {
@@ -466,7 +473,38 @@ func addDir(writer *tar.Writer, dirpath string, ignoreSet map[string]struct{}) e
 	return nil
 }
 
+func singleFile(writer *tar.Writer, filepath string) error {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fi, err := os.Lstat(filepath)
+	if err != nil {
+		return err
+	}
+	header, err := tar.FileInfoHeader(fi, "")
+	if err != nil {
+		return err
+	}
+	fp := strings.Split(filepath, "/")
+	header.Name = fp[len(fp)-1]
+	err = writer.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+	n, err := io.Copy(writer, f)
+	if err != nil {
+		return err
+	}
+	if n != fi.Size() {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
 func addFile(writer *tar.Writer, filepath string) error {
+	fmt.Println(filepath)
 	f, err := os.Open(filepath)
 	if err != nil {
 		return err

--- a/tsuru/client/deploy.go
+++ b/tsuru/client/deploy.go
@@ -122,10 +122,10 @@ func (c *AppDeployList) Run(context *cmd.Context, client *cmd.Client) error {
 
 type AppDeploy struct {
 	cmd.GuessingCommand
-	image       string
-	message     string
-	singleFiles bool
-	fs          *gnuflag.FlagSet
+	image    string
+	message  string
+	rootFile bool
+	fs       *gnuflag.FlagSet
 }
 
 func (c *AppDeploy) Flags() *gnuflag.FlagSet {
@@ -137,9 +137,9 @@ func (c *AppDeploy) Flags() *gnuflag.FlagSet {
 		message := "A message describing this deploy"
 		c.fs.StringVar(&c.message, "message", "", message)
 		c.fs.StringVar(&c.message, "m", "", message)
-		sf := "enables single file deployment"
-		c.fs.BoolVar(&c.singleFiles, "s", false, sf)
-		c.fs.BoolVar(&c.singleFiles, "single-files", false, sf)
+		rf := "Enables single file deployment into the root of the app's tree"
+		c.fs.BoolVar(&c.rootFile, "r", false, rf)
+		c.fs.BoolVar(&c.rootFile, "root-file", false, rf)
 	}
 	return c.fs
 }
@@ -157,7 +157,7 @@ calls are:
 `
 	return &cmd.Info{
 		Name:    "app-deploy",
-		Usage:   "app-deploy [-a/--app <appname>] [-i/--image <image_url>] [-m/--message <message>] <file-or-dir-1> [file-or-dir-2] ... [file-or-dir-n]",
+		Usage:   "app-deploy [-a/--app <appname>] [-i/--image <image_url>] [-m/--message <message>] [-r/--root-file] <file-or-dir-1> [file-or-dir-2] ... [file-or-dir-n]",
 		Desc:    desc,
 		MinArgs: 0,
 	}
@@ -249,7 +249,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 				ignoreSet[k] = v
 			}
 		}
-		err = targz(context, file, ignoreSet, c.singleFiles, context.Args...)
+		err = targz(context, file, ignoreSet, c.rootFile, context.Args...)
 		if err != nil {
 			return err
 		}
@@ -281,7 +281,6 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 			}
 		}()
 	}
-	// fmt.Println(c.singleFiles)
 	resp, err := client.Do(request)
 	if err != nil {
 		return err
@@ -369,7 +368,7 @@ func readTsuruIgnore() ([]string, error) {
 	return patterns, nil
 }
 
-func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{}, singleFiles bool, filepaths ...string) error {
+func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{}, rootFile bool, filepaths ...string) error {
 	var buf bytes.Buffer
 	tarWriter := tar.NewWriter(&buf)
 	for _, path := range filepaths {
@@ -394,7 +393,7 @@ func targz(ctx *cmd.Context, destination io.Writer, ignoreSet map[string]struct{
 				return singleDir(ctx, destination, path, ignoreSet)
 			}
 			err = addDir(tarWriter, path, ignoreSet)
-		} else if singleFiles {
+		} else if rootFile {
 			err = singleFile(tarWriter, path)
 		} else {
 			err = addFile(tarWriter, path)
@@ -504,7 +503,6 @@ func singleFile(writer *tar.Writer, filepath string) error {
 }
 
 func addFile(writer *tar.Writer, filepath string) error {
-	fmt.Println(filepath)
 	f, err := os.Open(filepath)
 	if err != nil {
 		return err

--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -225,7 +225,7 @@ func (s *S) TestDeployRunWithFlagToFiles(c *check.C) {
 	fake := cmdtest.FakeGuesser{Name: "leblank"}
 	guessCommand := cmd.GuessingCommand{G: &fake}
 	cmd := AppDeploy{GuessingCommand: guessCommand}
-	cmd.Flags().Parse(true, []string{"-s"})
+	cmd.Flags().Parse(true, []string{"-r"})
 	err = cmd.Run(&context, client)
 	c.Assert(err, check.IsNil)
 	c.Assert(calledTimes, check.Equals, 2)

--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -34,7 +34,7 @@ func (s *S) TestDeployRun(c *check.C) {
 	calledTimes := 0
 	var buf bytes.Buffer
 	ctx := cmd.Context{Stderr: bytes.NewBufferString("")}
-	err := targz(&ctx, &buf, nil, "testdata", "..")
+	err := targz(&ctx, &buf, nil, false, "testdata", "..")
 	c.Assert(err, check.IsNil)
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},
@@ -109,7 +109,7 @@ func (s *S) TestDeployRunWithMessage(c *check.C) {
 	calledTimes := 0
 	var buf bytes.Buffer
 	ctx := cmd.Context{Stderr: bytes.NewBufferString("")}
-	err := targz(&ctx, &buf, nil, "testdata", "..")
+	err := targz(&ctx, &buf, nil, false, "testdata", "..")
 	c.Assert(err, check.IsNil)
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},
@@ -152,7 +152,7 @@ func (s *S) TestDeployRunWithFiles(c *check.C) {
 	calledTimes := 0
 	var buf bytes.Buffer
 	ctx := cmd.Context{Stderr: bytes.NewBufferString("")}
-	err := targz(&ctx, &buf, nil, "testdata/deploy/file1.txt", "testdata/deploy2/file2.txt")
+	err := targz(&ctx, &buf, nil, false, "testdata/deploy/file1.txt", "testdata/deploy2/file2.txt")
 	c.Assert(err, check.IsNil)
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},
@@ -184,6 +184,48 @@ func (s *S) TestDeployRunWithFiles(c *check.C) {
 	fake := cmdtest.FakeGuesser{Name: "leblank"}
 	guessCommand := cmd.GuessingCommand{G: &fake}
 	cmd := AppDeploy{GuessingCommand: guessCommand}
+	err = cmd.Run(&context, client)
+	c.Assert(err, check.IsNil)
+	c.Assert(calledTimes, check.Equals, 2)
+}
+
+func (s *S) TestDeployRunWithFlagToFiles(c *check.C) {
+	calledTimes := 0
+	var buf bytes.Buffer
+	ctx := cmd.Context{Stderr: bytes.NewBufferString("")}
+	err := targz(&ctx, &buf, nil, true, "testdata/deploy/file1.txt", "testdata/deploy2/file2.txt")
+	c.Assert(err, check.IsNil)
+	trans := cmdtest.ConditionalTransport{
+		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},
+		CondFunc: func(req *http.Request) bool {
+			calledTimes++
+			if req.Body != nil {
+				defer req.Body.Close()
+			}
+			if calledTimes == 1 {
+				return req.Method == "GET" && strings.HasSuffix(req.URL.Path, "/apps/leblank")
+			}
+			file, _, transErr := req.FormFile("file")
+			c.Assert(transErr, check.IsNil)
+			content, transErr := ioutil.ReadAll(file)
+			c.Assert(transErr, check.IsNil)
+			c.Assert(content, check.DeepEquals, buf.Bytes())
+			c.Assert(req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
+			c.Assert(req.FormValue("origin"), check.Equals, "app-deploy")
+			return req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/apps/leblank/deploy")
+		},
+	}
+	client := cmd.NewClient(&http.Client{Transport: &trans}, nil, manager)
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Args:   []string{"testdata/deploy/file1.txt", "testdata/deploy2/file2.txt"},
+	}
+	fake := cmdtest.FakeGuesser{Name: "leblank"}
+	guessCommand := cmd.GuessingCommand{G: &fake}
+	cmd := AppDeploy{GuessingCommand: guessCommand}
+	cmd.Flags().Parse(true, []string{"-s"})
 	err = cmd.Run(&context, client)
 	c.Assert(err, check.IsNil)
 	c.Assert(calledTimes, check.Equals, 2)
@@ -301,7 +343,7 @@ func (s *S) TestTargz(c *check.C) {
 	var buf bytes.Buffer
 	ctx := cmd.Context{Stderr: &buf}
 	var gzipBuf, tarBuf bytes.Buffer
-	err := targz(&ctx, &gzipBuf, nil, "testdata/deploy", "..")
+	err := targz(&ctx, &gzipBuf, nil, false, "testdata/deploy", "..")
 	c.Assert(err, check.IsNil)
 	gzipReader, err := gzip.NewReader(&gzipBuf)
 	c.Assert(err, check.IsNil)
@@ -336,7 +378,7 @@ func (s *S) TestTargzParsingFiles(c *check.C) {
 	var buf bytes.Buffer
 	ctx := cmd.Context{Stderr: &buf}
 	var gzipBuf, tarBuf bytes.Buffer
-	err := targz(&ctx, &gzipBuf, nil, "testdata/deploy/file1.txt", "testdata/deploy/file2.txt")
+	err := targz(&ctx, &gzipBuf, nil, false, "testdata/deploy/file1.txt", "testdata/deploy/file2.txt")
 	c.Assert(err, check.IsNil)
 	gzipReader, err := gzip.NewReader(&gzipBuf)
 	c.Assert(err, check.IsNil)
@@ -367,7 +409,7 @@ func (s *S) TestTargzSingleDirectory(c *check.C) {
 	var buf bytes.Buffer
 	ctx := cmd.Context{Stderr: &buf}
 	var gzipBuf, tarBuf bytes.Buffer
-	err := targz(&ctx, &gzipBuf, nil, "testdata/deploy")
+	err := targz(&ctx, &gzipBuf, nil, false, "testdata/deploy")
 	c.Assert(err, check.IsNil)
 	gzipReader, err := gzip.NewReader(&gzipBuf)
 	c.Assert(err, check.IsNil)
@@ -401,7 +443,7 @@ func (s *S) TestTargzSymlink(c *check.C) {
 	var buf bytes.Buffer
 	ctx := cmd.Context{Stderr: &buf}
 	var gzipBuf, tarBuf bytes.Buffer
-	err := targz(&ctx, &gzipBuf, nil, "testdata-symlink", "..")
+	err := targz(&ctx, &gzipBuf, nil, false, "testdata-symlink", "..")
 	c.Assert(err, check.IsNil)
 	gzipReader, err := gzip.NewReader(&gzipBuf)
 	c.Assert(err, check.IsNil)
@@ -422,7 +464,7 @@ func (s *S) TestTargzFailure(c *check.C) {
 	var stderr bytes.Buffer
 	ctx := cmd.Context{Stderr: &stderr}
 	var buf bytes.Buffer
-	err := targz(&ctx, &buf, nil, "/tmp/something/that/definitely/doesn't/exist/right", "testdata")
+	err := targz(&ctx, &buf, nil, false, "/tmp/something/that/definitely/doesn't/exist/right", "testdata")
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Matches, ".*(no such file or directory|cannot find the path specified).*")
 }
@@ -607,7 +649,7 @@ func (s *S) TestIgnoreGlobalFiles(c *check.C) {
 	}
 	ctx := cmd.Context{Stderr: &buf}
 	var gzipBuf, tarBuf bytes.Buffer
-	err := targz(&ctx, &gzipBuf, ignore, "testdata/deploy2")
+	err := targz(&ctx, &gzipBuf, ignore, false, "testdata/deploy2")
 	c.Assert(err, check.IsNil)
 	gzipReader, err := gzip.NewReader(&gzipBuf)
 	c.Assert(err, check.IsNil)
@@ -637,7 +679,7 @@ func (s *S) TestIgnoreDir(c *check.C) {
 	}
 	ctx := cmd.Context{Stderr: &buf}
 	var gzipBuf, tarBuf bytes.Buffer
-	err := targz(&ctx, &gzipBuf, ignore, "testdata/deploy2")
+	err := targz(&ctx, &gzipBuf, ignore, false, "testdata/deploy2")
 	c.Assert(err, check.IsNil)
 	gzipReader, err := gzip.NewReader(&gzipBuf)
 	c.Assert(err, check.IsNil)
@@ -667,7 +709,7 @@ func (s *S) TestIgnoreRelativeDir(c *check.C) {
 	}
 	ctx := cmd.Context{Stderr: &buf}
 	var gzipBuf, tarBuf bytes.Buffer
-	err := targz(&ctx, &gzipBuf, ignore, "testdata/deploy2")
+	err := targz(&ctx, &gzipBuf, ignore, false, "testdata/deploy2")
 	c.Assert(err, check.IsNil)
 	gzipReader, err := gzip.NewReader(&gzipBuf)
 	c.Assert(err, check.IsNil)
@@ -697,7 +739,7 @@ func (s *S) TestIgnoreRelativeFile(c *check.C) {
 	}
 	ctx := cmd.Context{Stderr: &buf}
 	var gzipBuf, tarBuf bytes.Buffer
-	err := targz(&ctx, &gzipBuf, ignore, "testdata/deploy2")
+	err := targz(&ctx, &gzipBuf, ignore, false, "testdata/deploy2")
 	c.Assert(err, check.IsNil)
 	gzipReader, err := gzip.NewReader(&gzipBuf)
 	c.Assert(err, check.IsNil)

--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -225,7 +225,7 @@ func (s *S) TestDeployRunWithFlagToFiles(c *check.C) {
 	fake := cmdtest.FakeGuesser{Name: "leblank"}
 	guessCommand := cmd.GuessingCommand{G: &fake}
 	cmd := AppDeploy{GuessingCommand: guessCommand}
-	cmd.Flags().Parse(true, []string{"-r"})
+	cmd.Flags().Parse(true, []string{"-f"})
 	err = cmd.Run(&context, client)
 	c.Assert(err, check.IsNil)
 	c.Assert(calledTimes, check.Equals, 2)


### PR DESCRIPTION
This enables the client to ignore the path and use only the file provided by the app-deploy command. Also provides two tests to garante the behavior of keeping the path of files while deploying files.

Fixes tsuru/tsuru#1577