### PR TITLE
client: properly handle empty plan list

### DIFF
--- a/tsuru/client/volume.go
+++ b/tsuru/client/volume.go
@@ -254,14 +254,16 @@ func (c *VolumePlansList) Run(ctx *cmd.Context, client *cmd.Client) error {
 		return err
 	}
 	defer rsp.Body.Close()
-	data, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		return err
-	}
 	var plans map[string][]volume.VolumePlan
-	err = json.Unmarshal(data, &plans)
-	if err != nil {
-		return err
+	if rsp.StatusCode != http.StatusNoContent {
+		data, err := ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal(data, &plans)
+		if err != nil {
+			return err
+		}
 	}
 	return c.render(ctx, plans)
 }

--- a/tsuru/client/volume_test.go
+++ b/tsuru/client/volume_test.go
@@ -105,6 +105,29 @@ func (s *S) TestVolumePlansList(c *check.C) {
 `)
 }
 
+func (s *S) TestVolumePlansListEmpty(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	ctx := cmd.Context{
+		Args:   []string{},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	trans := &cmdtest.ConditionalTransport{
+		Transport: cmdtest.Transport{Status: http.StatusNoContent},
+		CondFunc: func(req *http.Request) bool {
+			return strings.HasSuffix(req.URL.Path, "/volumeplans") && req.Method == "GET"
+		},
+	}
+	client := cmd.NewClient(&http.Client{Transport: trans}, nil, manager)
+	err := (&VolumePlansList{}).Run(&ctx, client)
+	c.Assert(err, check.IsNil)
+	result := stdout.String()
+	c.Assert(result, check.Equals, `+------+-------------+------+
+| Plan | Provisioner | Opts |
++------+-------------+------+
+`)
+}
+
 func (s *S) TestVolumeCreate(c *check.C) {
 	var stdout, stderr bytes.Buffer
 	ctx := cmd.Context{


### PR DESCRIPTION
Prevents `Error: unexpected end of JSON input` on empty plan list.