### PR TITLE
installer: enables customizing tsuru api image

### DIFF
--- a/tsuru/installer/components.go
+++ b/tsuru/installer/components.go
@@ -24,6 +24,7 @@ type ComponentsConfig struct {
 	TargetName       string `yaml:"-"`
 	RootUserEmail    string `yaml:"-"`
 	RootUserPassword string `yaml:"-"`
+	TsuruAPIImage    string `yaml:"tsuru-image,omitempty"`
 	Tsuru            tsuruComponent
 }
 

--- a/tsuru/installer/compose.go
+++ b/tsuru/installer/compose.go
@@ -32,6 +32,7 @@ func composeDeploy(c ServiceCluster, installConfig *InstallOpts) error {
 	configs := map[string]string{
 		"CLUSTER_ADDR":         manager.Base.Address,
 		"CLUSTER_PRIVATE_ADDR": dm.GetPrivateIP(manager),
+		"TSURU_API_IMAGE":      installConfig.ComponentsConfig.TsuruAPIImage,
 	}
 	config, err := resolveConfig(installConfig.ComposeFile, configs)
 	if err != nil {

--- a/tsuru/installer/defaultconfig/compose.yml
+++ b/tsuru/installer/defaultconfig/compose.yml
@@ -40,7 +40,7 @@ services:
       - tsuru
 
   tsuru:
-    image: tsuru/api:v1
+    image: "{{TSURU_API_IMAGE}}"
     volumes:
       - "/etc/docker/certs.d:/certs:ro"
       - "/etc/tsuru/tsuru.conf:/etc/tsuru/tsuru.conf:ro"

--- a/tsuru/installer/defaultconfig/configs.go
+++ b/tsuru/installer/defaultconfig/configs.go
@@ -45,7 +45,7 @@ services:
       - tsuru
 
   tsuru:
-    image: tsuru/api:v1
+    image: "{{TSURU_API_IMAGE}}"
     volumes:
       - "/etc/docker/certs.d:/certs:ro"
       - "/etc/tsuru/tsuru.conf:/etc/tsuru/tsuru.conf:ro"

--- a/tsuru/installer/install_test.go
+++ b/tsuru/installer/install_test.go
@@ -73,6 +73,7 @@ func (s *S) TestParseConfigFile(c *check.C) {
 			RootUserEmail:    "admin@example.com",
 			RootUserPassword: "admin123",
 			Tsuru:            tsuruComponent{Config: expectedTsuruConf},
+			TsuruAPIImage:    "tsuru/api:latest",
 		},
 		Hosts: hostGroups{
 			Apps: hostGroupConfig{

--- a/tsuru/installer/installer.go
+++ b/tsuru/installer/installer.go
@@ -38,6 +38,7 @@ func DefaultInstallOpts() *InstallOpts {
 			TargetName:       "tsuru",
 			RootUserEmail:    "admin@example.com",
 			RootUserPassword: "admin123",
+			TsuruAPIImage:    "tsuru/api:v1",
 			Tsuru:            tsuruComponent{Config: defaultconfig.DefaultTsuruConfig()},
 		},
 		Hosts: hostGroups{

--- a/tsuru/installer/testdata/hosts.yml
+++ b/tsuru/installer/testdata/hosts.yml
@@ -18,6 +18,7 @@ driver:
         opt1: option1-value
         opt2: option2-value
 components:
+    tsuru-image: "tsuru/api:latest"
     tsuru:
         config:
             debug: true


### PR DESCRIPTION
This PR makes its easier to choose a particular tsuru api image and prevents having to generate a complete compose file just for this small and probably common configuration.