### PR TITLE
event: clarifies event cancellation message

### DIFF
--- a/tsuru/client/event.go
+++ b/tsuru/client/event.go
@@ -320,6 +320,6 @@ func (c *EventCancel) Run(context *cmd.Context, client *cmd.Client) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(context.Stdout, "Event successfully canceled.")
+	fmt.Fprintln(context.Stdout, "Cancellation successfully requested.")
 	return nil
 }

--- a/tsuru/client/event_test.go
+++ b/tsuru/client/event_test.go
@@ -521,5 +521,5 @@ func (s *S) TestEventCancel(c *check.C) {
 	command.Flags().Parse(true, []string{"-y"})
 	err := command.Run(&context, client)
 	c.Assert(err, check.IsNil)
-	c.Assert(stdout.String(), check.Matches, "Event successfully canceled.\n")
+	c.Assert(stdout.String(), check.Matches, "Cancellation successfully requested.\n")
 }


### PR DESCRIPTION
Event cancellation is async so we can't tell if the event was really cancelled right after the cancellation was requested.