### PR TITLE
vendor: override Gotty to fix array out-of-bounds access panic

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,10 +47,10 @@
   revision = "d8f60f2dd117cd64c2825143a89ecb6f158ad743"
 
 [[projects]]
-  branch = "master"
   name = "github.com/Nvveen/Gotty"
   packages = ["."]
-  revision = "cd527374f1e5bff4938207604a14f2e38a9cf512"
+  revision = "a8b993ba6abdb0e0c12b0125c603323a71c7790c"
+  source = "https://github.com/ijc25/Gotty.git"
 
 [[projects]]
   name = "github.com/RobotsAndPencils/go-saml"
@@ -651,6 +651,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "14cb7be988c915395ea2ba8cec55a6737b90f7be47dd569608f0206b62243fdc"
+  inputs-digest = "3a528323a3829489352fb596f3c182a972d7bdd589c205038870199a82221fcc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -99,6 +99,10 @@
 [[override]]
   name = "github.com/rackspace/gophercloud"
   revision = "c90cb954266e1bdd6d1914678fd6909fc5fabbfa"
+[[override]]
+  name = "github.com/Nvveen/Gotty"
+  source = "https://github.com/ijc25/Gotty.git"
+  revision = "a8b993ba6abdb0e0c12b0125c603323a71c7790c"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/Nvveen/Gotty/gotty.go
+++ b/vendor/github.com/Nvveen/Gotty/gotty.go
@@ -8,10 +8,12 @@ package gotty
 // TODO add more concurrency to name lookup, look for more opportunities.
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"reflect"
 	"strings"
 	"sync"
@@ -21,33 +23,30 @@ import (
 // If something went wrong reading the terminfo database file, an error is
 // returned.
 func OpenTermInfo(termName string) (*TermInfo, error) {
-	var term *TermInfo
-	var err error
+	if len(termName) == 0 {
+		return nil, errors.New("No termname given")
+	}
 	// Find the environment variables
-	termloc := os.Getenv("TERMINFO")
-	if len(termloc) == 0 {
+	if termloc := os.Getenv("TERMINFO"); len(termloc) > 0 {
+		return readTermInfo(path.Join(termloc, string(termName[0]), termName))
+	} else {
 		// Search like ncurses
-		locations := []string{os.Getenv("HOME") + "/.terminfo/", "/etc/terminfo/",
-			"/lib/terminfo/", "/usr/share/terminfo/"}
-		var path string
+		locations := []string{}
+		if h := os.Getenv("HOME"); len(h) > 0 {
+			locations = append(locations, path.Join(h, ".terminfo"))
+		}
+		locations = append(locations,
+			"/etc/terminfo/",
+			"/lib/terminfo/",
+			"/usr/share/terminfo/")
 		for _, str := range locations {
-			// Construct path
-			path = str + string(termName[0]) + "/" + termName
-			// Check if path can be opened
-			file, _ := os.Open(path)
-			if file != nil {
-				// Path can open, fall out and use current path
-				file.Close()
-				break
+			term, err := readTermInfo(path.Join(str, string(termName[0]), termName))
+			if err == nil {
+				return term, nil
 			}
 		}
-		if len(path) > 0 {
-			term, err = readTermInfo(path)
-		} else {
-			err = errors.New(fmt.Sprintf("No terminfo file(-location) found"))
-		}
+		return nil, errors.New("No terminfo file(-location) found")
 	}
-	return term, err
 }
 
 // Open a terminfo file from the environment variable containing the current
@@ -110,7 +109,7 @@ func (term *TermInfo) GetAttributeName(name string) (stacker, error) {
 	return term.GetAttribute(tc)
 }
 
-// A utility function that finds and returns the termcap equivalent of a 
+// A utility function that finds and returns the termcap equivalent of a
 // variable name.
 func GetTermcapName(name string) string {
 	// Termcap name
@@ -192,7 +191,9 @@ func readTermInfo(path string) (*TermInfo, error) {
 		}
 	}
 	// If the number of bytes read is not even, a byte for alignment is added
-	if len(byteArray)%2 != 0 {
+	// We know the header is an even number of bytes so only need to check the
+	// total of the names and booleans.
+	if (header[1]+header[2])%2 != 0 {
 		err = binary.Read(file, binary.LittleEndian, make([]byte, 1))
 		if err != nil {
 			return nil, err
@@ -228,9 +229,14 @@ func readTermInfo(path string) (*TermInfo, error) {
 	// We get an offset, and then iterate until the string is null-terminated
 	for i, offset := range shArray {
 		if offset > -1 {
-			r := offset
-			for ; byteArray[r] != 0; r++ {
+			if int(offset) >= len(byteArray) {
+				return nil, errors.New("array out of bounds reading string section")
 			}
+			r := bytes.IndexByte(byteArray[offset:], 0)
+			if r == -1 {
+				return nil, errors.New("missing nul byte reading string section")
+			}
+			r += int(offset)
 			term.strAttributes[StrAttr[i*2+1]] = string(byteArray[offset:r])
 		}
 	}


### PR DESCRIPTION
Issue https://github.com/tsuru/tsuru/issues/1936

This PR overrides Gotty docker dependence, 
using the fork: https://github.com/ijc/Gotty 
that implemented the PR: https://github.com/Nvveen/Gotty/pull/1
as made by docker: https://github.com/moby/moby/blob/17bb1d3663f6586e83b453670526e3186bb56dd3/vendor.conf#L141:12
