### PR TITLE
misc: autocomplete commands with space separator

### DIFF
--- a/misc/bash-completion
+++ b/misc/bash-completion
@@ -3,12 +3,28 @@
 # license that can be found in the LICENSE file.
 
 _tsuru() {
-    local tasks=""
-    if [ ${#COMP_WORDS[@]} -lt 3 ]
-    then
-        tasks=`tsuru | egrep "^[  ]" | awk -F ' ' '{print $1}'`
+    local tasks=`tsuru | egrep "^[  ]" | awk -F ' ' '{print $1}'`
+
+    if [ ${#COMP_WORDS[@]} -eq 2 ]; then
+        local current=${COMP_WORDS[COMP_CWORD]}
+        if [ -n "${current}" ]; then
+            COMPREPLY=( $(compgen -W "$tasks" $current) )
+            return
+        fi
     fi
-    local current=${COMP_WORDS[COMP_CWORD]}
-    COMPREPLY=( $(compgen -W "$tasks" $current) )
+
+    let last_complete=COMP_CWORD-1
+    local base_cmd=""
+    for i in $(seq 1 1 $last_complete 2>/dev/null); do
+        local current=${COMP_WORDS[i]}
+        if [[ "$current" == "-*" ]]; then
+            break
+        fi
+        base_cmd="${base_cmd}${current}-"
+    done
+    local incomplete_command="${base_cmd}${COMP_WORDS[COMP_CWORD]}"
+    local genlist=$(compgen -W "$tasks" "$incomplete_command")
+    genlist=$(echo "$genlist" | sed "s/^${base_cmd}//" | sed 's/-.*$//')
+    COMPREPLY=( $(compgen -W "$genlist") )
 }
 complete -F _tsuru -o bashdefault -o default tsuru


### PR DESCRIPTION
An example of the new behavior for the bash completion:

```
$ tsuru app r<TAB><TAB>
remove   restart  revoke   router   routes   run

$ tsuru app router <TAB><TAB>
add     list    remove  update

$ tsuru <TAB><TAB>
app          cname        event        key          permission   reset        target       version
bs           container    healing      login        plan         role         team         volume
certificate  containers   help         logout       platform     router       token
change       docker       init         machine      plugin       service      unit
cluster      env          install      node         pool         tag          user

$ tsuru ap<TAB>
$ tsuru app<TAB><TAB>
app                         app-grant                   app-revoke                  app-start
app-build                   app-info                    app-router-add              app-stop
app-create                  app-list                    app-router-list             app-swap
app-deploy                  app-log                     app-router-remove           app-unlock
app-deploy-list             app-quota-change            app-router-update           app-update
app-deploy-rebuild          app-quota-view              app-routes-rebuild
app-deploy-rollback         app-remove                  app-run
app-deploy-rollback-update  app-restart                 app-shell

$ tsuru app <TAB><TAB>
build    deploy   info     log      remove   revoke   routes   shell    stop     unlock
create   grant    list     quota    restart  router   run      start    swap     update
```