### PR TITLE
Fix tsuru-client's build on Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+bin
+docs
+misc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM tsuru/alpine-go:latest as builder
-COPY . /go/src/github.com/tsuru/tsuru-client
-WORKDIR /go/src/github.com/tsuru/tsuru-client
-ENV CC=/usr/bin/gcc
-ENV GOPATH=/go
-RUN go build -i -v --ldflags '-linkmode external -extldflags "-static"' -o ./bin/tsuru ./tsuru
+FROM golang:1.10-alpine AS builder
 
-FROM alpine:3.4
-RUN apk update && apk add --no-cache ca-certificates
+COPY . /go/src/github.com/tsuru/tsuru-client
+
+WORKDIR /go/src/github.com/tsuru/tsuru-client
+
+RUN apk add --update gcc git make musl-dev && \
+    make build
+
+FROM alpine:3.8
+
 COPY --from=builder /go/src/github.com/tsuru/tsuru-client/bin/tsuru /bin/tsuru
+
+RUN apk update && \
+    apk add --no-cache ca-certificates && \
+    rm /var/cache/apk/*
+
 CMD ["tsuru"]


### PR DESCRIPTION
Currently, the `tsuru/client` image isn't building as expected on Docker Hub, see the last builds history. I think that's is related with absence of `musl-dev` package on the system, as mentioned on [this issue](https://github.com/docker-library/golang/issues/86).

In this PR, besides fixing the build I also updated the Alpine to its last version. :)
