### PR TITLE
Merge `service-instance-info` and `service-instance-status` commands

### DIFF
--- a/tsuru/client/services.go
+++ b/tsuru/client/services.go
@@ -353,49 +353,6 @@ func (su *ServiceInstanceUnbind) Flags() *gnuflag.FlagSet {
 	return su.fs
 }
 
-type ServiceInstanceStatus struct{}
-
-func (c ServiceInstanceStatus) Info() *cmd.Info {
-	return &cmd.Info{
-		Name:  "service-instance-status",
-		Usage: "service-instance-status <service-name> <service-instance-name>",
-		Desc: `Displays the status of the given service instance. For now, it checks only if
-the instance is "up" (receiving connections) or "down" (refusing connections).`,
-		MinArgs: 2,
-	}
-}
-
-func (c ServiceInstanceStatus) Run(ctx *cmd.Context, client *cmd.Client) error {
-	servName := ctx.Args[0]
-	instName := ctx.Args[1]
-	url, err := cmd.GetURL("/services/" + servName + "/instances/" + instName + "/status")
-	if err != nil {
-		return err
-	}
-	request, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := client.Do(request)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	bMsg, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	msg := string(bMsg) + "\n"
-	n, err := fmt.Fprint(ctx.Stdout, msg)
-	if err != nil {
-		return err
-	}
-	if n != len(msg) {
-		return errors.New("Failed to write to standard output.\n")
-	}
-	return nil
-}
-
 type ServiceInstanceInfo struct{}
 
 func (c ServiceInstanceInfo) Info() *cmd.Info {
@@ -487,7 +444,7 @@ func (c ServiceInstanceInfo) Run(ctx *cmd.Context, client *cmd.Client) error {
 	if err != nil {
 		return err
 	}
-	msg := string(bMsg) + "\n"
+	msg := fmt.Sprintf("Status: %s\n", bMsg)
 	n, err := fmt.Fprint(ctx.Stdout, msg)
 	if err != nil {
 		return err

--- a/tsuru/client/services.go
+++ b/tsuru/client/services.go
@@ -469,6 +469,32 @@ func (c ServiceInstanceInfo) Run(ctx *cmd.Context, client *cmd.Client) error {
 			}
 		}
 	}
+
+	url, err = cmd.GetURL("/services/" + serviceName + "/instances/" + instanceName + "/status")
+	if err != nil {
+		return err
+	}
+	request, err = http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err = client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	bMsg, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	msg := string(bMsg) + "\n"
+	n, err := fmt.Fprint(ctx.Stdout, msg)
+	if err != nil {
+		return err
+	}
+	if n != len(msg) {
+		return errors.New("Failed to write to standard output.\n")
+	}
 	return nil
 }
 

--- a/tsuru/client/services.go
+++ b/tsuru/client/services.go
@@ -130,7 +130,6 @@ func (c *ServiceInstanceAdd) Run(ctx *cmd.Context, client *cmd.Client) error {
 		return err
 	}
 	fmt.Fprint(ctx.Stdout, "Service instance successfully added.\n")
-	fmt.Fprintf(ctx.Stdout, "To check its status use: tsuru service instance status %s %s\n", serviceName, instanceName)
 	fmt.Fprintf(ctx.Stdout, "For additional information use: tsuru service instance info %s %s\n", serviceName, instanceName)
 	return nil
 }

--- a/tsuru/client/services_test.go
+++ b/tsuru/client/services_test.go
@@ -367,7 +367,7 @@ func (s *S) TestServiceInstanceAddInfo(c *check.C) {
 
 func (s *S) TestServiceInstanceAddRun(c *check.C) {
 	var stdout, stderr bytes.Buffer
-	result := "Service instance successfully added.\nTo check its status use: tsuru service instance status mysql my_app_db\nFor additional information use: tsuru service instance info mysql my_app_db\n"
+	result := "Service instance successfully added.\nFor additional information use: tsuru service instance info mysql my_app_db\n"
 	args := []string{
 		"mysql",
 		"my_app_db",
@@ -426,7 +426,7 @@ func (s *S) TestServiceInstanceAddRun(c *check.C) {
 
 func (s *S) TestServiceInstanceAddRunWithEmptyTag(c *check.C) {
 	var stdout, stderr bytes.Buffer
-	result := "Service instance successfully added.\nTo check its status use: tsuru service instance status mysql my_app_db\nFor additional information use: tsuru service instance info mysql my_app_db\n"
+	result := "Service instance successfully added.\nFor additional information use: tsuru service instance info mysql my_app_db\n"
 	args := []string{
 		"mysql",
 		"my_app_db",

--- a/tsuru/client/services_test.go
+++ b/tsuru/client/services_test.go
@@ -86,6 +86,9 @@ Service test is foo bar.
 			message = `{"Apps": ["app", "app2"], "Teams": ["admin", "admin2"], "TeamOwner": "admin", "CustomInfo" : {},"Description": "", "PlanName": "", "PlanDescription": "", "Tags": []}`
 		}
 	}
+	if strings.HasSuffix(req.URL.Path, "/status") {
+		message = `Service instance "mongo" is up`
+	}
 	resp = &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewBufferString(message)),
 		StatusCode: http.StatusOK,
@@ -712,6 +715,7 @@ key3:
 
 key4:
 	value8
+Service instance "mongo" is up
 `
 	args := []string{"mymongo", "mongo"}
 	context := cmd.Context{
@@ -737,6 +741,7 @@ Description:
 Tags:
 Plan:
 Plan description:
+Service instance "mongo" is up
 `
 	args := []string{"mymongo", "mongo"}
 	context := cmd.Context{

--- a/tsuru/client/services_test.go
+++ b/tsuru/client/services_test.go
@@ -658,28 +658,6 @@ func (s *S) TestServiceInstanceUpdateFlags(c *check.C) {
 	c.Check(assume.DefValue, check.Equals, "")
 }
 
-func (s *S) TestServiceInstanceStatusInfo(c *check.C) {
-	got := (&ServiceInstanceStatus{}).Info()
-	c.Assert(got, check.NotNil)
-}
-
-func (s *S) TestServiceInstanceStatusRun(c *check.C) {
-	var stdout, stderr bytes.Buffer
-	result := `Service instance "foo" is up`
-	args := []string{"foo", "fooBar"}
-	context := cmd.Context{
-		Args:   args,
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}
-	client := cmd.NewClient(&http.Client{Transport: &cmdtest.Transport{Message: result, Status: http.StatusOK}}, nil, manager)
-	err := (&ServiceInstanceStatus{}).Run(&context, client)
-	c.Assert(err, check.IsNil)
-	obtained := stdout.String()
-	obtained = strings.Replace(obtained, "\n", "", -1)
-	c.Assert(obtained, check.Equals, result)
-}
-
 func (s *S) TestServiceInfoInfo(c *check.C) {
 	got := (&ServiceInfo{}).Info()
 	c.Assert(got, check.NotNil)
@@ -715,7 +693,7 @@ key3:
 
 key4:
 	value8
-Service instance "mongo" is up
+Status: Service instance "mongo" is up
 `
 	args := []string{"mymongo", "mongo"}
 	context := cmd.Context{
@@ -741,7 +719,7 @@ Description:
 Tags:
 Plan:
 Plan description:
-Service instance "mongo" is up
+Status: Service instance "mongo" is up
 `
 	args := []string{"mymongo", "mongo"}
 	context := cmd.Context{

--- a/tsuru/main.go
+++ b/tsuru/main.go
@@ -59,7 +59,6 @@ func buildManager(name string) *cmd.Manager {
 	m.Register(&client.ServiceInstanceUpdate{})
 	m.Register(&client.ServiceInstanceRemove{})
 	m.Register(client.ServiceInfo{})
-	m.Register(client.ServiceInstanceStatus{})
 	m.Register(&client.ServiceInstanceGrant{})
 	m.Register(&client.ServiceInstanceRevoke{})
 	m.Register(&client.ServiceInstanceBind{})

--- a/tsuru/main.go
+++ b/tsuru/main.go
@@ -59,7 +59,6 @@ func buildManager(name string) *cmd.Manager {
 	m.Register(&client.ServiceInstanceUpdate{})
 	m.Register(&client.ServiceInstanceRemove{})
 	m.Register(client.ServiceInfo{})
-	m.Register(client.ServiceInstanceInfo{})
 	m.Register(client.ServiceInstanceStatus{})
 	m.Register(&client.ServiceInstanceGrant{})
 	m.Register(&client.ServiceInstanceRevoke{})
@@ -198,6 +197,7 @@ func buildManager(name string) *cmd.Manager {
 	m.RegisterDeprecated(&admin.AutoScaleSetRuleCmd{}, "docker-autoscale-rule-set")
 	m.RegisterDeprecated(&admin.AutoScaleDeleteRuleCmd{}, "docker-autoscale-rule-remove")
 	m.RegisterDeprecated(&admin.ListHealingHistoryCmd{}, "docker-healing-list")
+	m.RegisterDeprecated(client.ServiceInstanceInfo{}, "service-instance-status")
 	registerExtraCommands(m)
 	return m
 }

--- a/tsuru/main_test.go
+++ b/tsuru/main_test.go
@@ -203,6 +203,9 @@ func (s *S) TestServiceInstanceInfoIsRegistered(c *check.C) {
 	info, ok := manager.Commands["service-instance-info"]
 	c.Assert(ok, check.Equals, true)
 	c.Assert(info, check.FitsTypeOf, client.ServiceInstanceInfo{})
+	status, ok := manager.Commands["service-instance-status"]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(status, check.FitsTypeOf, &cmd.DeprecatedCommand{})
 }
 
 func (s *S) TestServiceInfoIsRegistered(c *check.C) {
@@ -210,13 +213,6 @@ func (s *S) TestServiceInfoIsRegistered(c *check.C) {
 	info, ok := manager.Commands["service-info"]
 	c.Assert(ok, check.Equals, true)
 	c.Assert(info, check.FitsTypeOf, client.ServiceInfo{})
-}
-
-func (s *S) TestServiceInstanceStatusIsRegistered(c *check.C) {
-	manager = buildManager("tsuru")
-	status, ok := manager.Commands["service-instance-status"]
-	c.Assert(ok, check.Equals, true)
-	c.Assert(status, check.FitsTypeOf, client.ServiceInstanceStatus{})
 }
 
 func (s *S) TestAppInfoIsRegistered(c *check.C) {


### PR DESCRIPTION
This PR deprecates the tsuru client service-instance-status command in favor of the service-instance-info command.  The service-instance-info command now also checks the status of the given service instance.

See https://github.com/tsuru/tsuru/issues/2167 for details.

@ggarnier for comments.