### PR TITLE
Add `unit-set` command

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -155,6 +155,8 @@ based on the git repository's configuration. It will try to find a remote labele
    :title: Add new units to an application
 .. tsuru-command:: unit-remove
    :title: Remove units from an application
+.. tsuru-command:: unit-set
+   :title: Set the desired number of units for an application's process
 .. tsuru-command:: app-grant
    :title: Allow a team to access an application
 .. tsuru-command:: app-revoke

--- a/tsuru/main.go
+++ b/tsuru/main.go
@@ -34,6 +34,7 @@ func buildManager(name string) *cmd.Manager {
 	m.Register(&client.AppUpdate{})
 	m.Register(&client.UnitAdd{})
 	m.Register(&client.UnitRemove{})
+	m.Register(&client.UnitSet{})
 	m.Register(&client.AppList{})
 	m.Register(&client.AppLog{})
 	m.Register(&client.AppGrant{})

--- a/tsuru/main_test.go
+++ b/tsuru/main_test.go
@@ -236,6 +236,13 @@ func (s *S) TestUnitRemoveIsRegistered(c *check.C) {
 	c.Assert(rmunit, check.FitsTypeOf, &client.UnitRemove{})
 }
 
+func (s *S) TestUnitSetIsRegistered(c *check.C) {
+	manager = buildManager("tsuru")
+	rmunit, ok := manager.Commands["unit-set"]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(rmunit, check.FitsTypeOf, &client.UnitSet{})
+}
+
 func (s *S) TestCNameAddIsRegistered(c *check.C) {
 	manager = buildManager("tsuru")
 	cname, ok := manager.Commands["cname-add"]


### PR DESCRIPTION
Usage:

```
$ tsuru unit-set web 10 -a my-app
$ tsuru unit-set worker 2 -a my-app
```

This is just a convenience command over `unit-add` and `unit-remove`.

The idea is to allow more easily to adjust the desired number of units for each process, without having to calculate how many units have to be added or removed to achieve that.

I've tried to build the docs but `make doc` would keep failing because of other commands and I didn't know how to fix it.