### PR TITLE
installer: try multiple ways of decoding base64 data

### DIFF
--- a/tsuru/installer/compose.go
+++ b/tsuru/installer/compose.go
@@ -42,7 +42,7 @@ func composeDeploy(c ServiceCluster, installConfig *InstallOpts) error {
 	if err != nil {
 		return fmt.Errorf("failed to write remote file: %s", err)
 	}
-	fmt.Print("Deploying compose file in cluster manager....\n")
+	fmt.Print("Deploying compose file in cluster manager...\n")
 	output, err := manager.Host.RunSSHCommand("sudo docker deploy -c /tmp/compose.yml tsuru")
 	if err != nil {
 		return err


### PR DESCRIPTION
Boot2docker image does not include base64 so we now fallback to either
openssl or python to do base64 decoding.

Fixes tsuru/tsuru#2279