### PR TITLE
feat: add app-metadata-{get/set/unset}

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/containerd/containerd v1.4.1 // indirect
 	github.com/digitalocean/godo v1.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v1.13.1
+	github.com/docker/docker v20.10.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/machine v0.16.1
 	github.com/exoscale/egoscale v0.9.31 // indirect
@@ -22,9 +22,9 @@ require (
 	github.com/sethvargo/go-password v0.1.1
 	github.com/tsuru/config v0.0.0-20201023175036-375aaee8b560
 	github.com/tsuru/gnuflag v0.0.0-20151217162021-86b8c1b864aa
-	github.com/tsuru/go-tsuruclient v0.0.0-20200917194500-f859f989a659
+	github.com/tsuru/go-tsuruclient v0.0.0-20210212185155-1a2f3d9e64cc
 	github.com/tsuru/tablecli v0.0.0-20190131152944-7ded8a3383c6
-	github.com/tsuru/tsuru v0.0.0-20210119182211-cf61c10f9104
+	github.com/tsuru/tsuru v0.0.0-20210212185225-da889133d5d9
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
 	google.golang.org/api v0.7.0 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
@@ -42,4 +42,5 @@ replace (
 	github.com/samalba/dockerclient => github.com/cezarsa/dockerclient v0.0.0-20190924055524-af5052a88081
 	gopkg.in/ahmetb/go-linq.v3 => github.com/ahmetb/go-linq v3.0.0+incompatible
 	gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405
+	golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6
 )

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -225,6 +226,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v0.0.0-20150414214848-547ef5ac9797 h1:XScp/7K55BJWgFeKalWP/2XvaRdhhhNJBOSQuFMS8mE=
 github.com/google/go-querystring v0.0.0-20150414214848-547ef5ac9797/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
@@ -320,6 +322,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -449,6 +452,8 @@ github.com/tsuru/gnuflag v0.0.0-20151217162021-86b8c1b864aa/go.mod h1:UibOSvkMFK
 github.com/tsuru/go-gandalfclient v0.0.0-20200928142220-6d227717b7c3/go.mod h1:p0UnkpWhQqUX4s3bzKPAYZ/rkz6NIS/PxsR8W4Opf3Q=
 github.com/tsuru/go-tsuruclient v0.0.0-20200917194500-f859f989a659 h1:2edEfTd50N1gZ/u+bP6S8GL+sMjQ9Rr2rsxddoeuOXw=
 github.com/tsuru/go-tsuruclient v0.0.0-20200917194500-f859f989a659/go.mod h1:KJLUM1rSes7I01GnjOgndownzYDbCOxxbTxMSzSctTA=
+github.com/tsuru/go-tsuruclient v0.0.0-20210212185155-1a2f3d9e64cc h1:biq0AAbdmYl2aBKxzHTuK5cfY2+30Oy0KQfwkIg8whM=
+github.com/tsuru/go-tsuruclient v0.0.0-20210212185155-1a2f3d9e64cc/go.mod h1:5/W1LtOsOE0uUGO0u57aVuXtHqFTxiiHpgkUlZNQzAc=
 github.com/tsuru/monsterqueue v0.0.0-20160909010522-70e946ec66c3 h1:+aJngj5cQjYyx/qSjffQceop25t97hLS0+t8bvx9hg4=
 github.com/tsuru/monsterqueue v0.0.0-20160909010522-70e946ec66c3/go.mod h1:3KR1vkjfm5b7Lhu5OXuO0NMIyZNG0d0d9xh6ufWYVxg=
 github.com/tsuru/tablecli v0.0.0-20180215113938-82de88f75181/go.mod h1:ztYpOhW+u1k21FEqp7nZNgpWbr0dUKok5lgGCZi+1AQ=
@@ -457,6 +462,8 @@ github.com/tsuru/tablecli v0.0.0-20190131152944-7ded8a3383c6/go.mod h1:ztYpOhW+u
 github.com/tsuru/tsuru v0.0.0-20180820205921-0e7f7f02eac5/go.mod h1:8EIA5MXZUPRxQR1lf8kQkcJVss0q+lv0L8f2nb23siQ=
 github.com/tsuru/tsuru v0.0.0-20210119182211-cf61c10f9104 h1:o9Ynj6/iYQLzs0IiZ4pF3q56yELhv7lgCyn9otyGwbM=
 github.com/tsuru/tsuru v0.0.0-20210119182211-cf61c10f9104/go.mod h1:Yy9W7DhM0WwnCUT9UF8yz1mL0+cTXZTQVZcfaGzjGQ8=
+github.com/tsuru/tsuru v0.0.0-20210212185225-da889133d5d9 h1:VgvxyYNjM5cT6wYQCsbqd/+E9Yqjk9LonFrJKzXjHFw=
+github.com/tsuru/tsuru v0.0.0-20210212185225-da889133d5d9/go.mod h1:Yy9W7DhM0WwnCUT9UF8yz1mL0+cTXZTQVZcfaGzjGQ8=
 github.com/uber-go/atomic v1.4.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber/jaeger-client-go v2.17.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
@@ -592,6 +599,10 @@ golang.org/x/sys v0.0.0-20200120151820-655fe14d7479/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6 h1:DvY3Zkh7KabQE/kfzMvYvKirSiguP9Q/veMtkYyf0o8=
+golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a h1:i47hUS795cOydZI4AwJQCKXOr4BvxzvikwDoDtHhP2Y=
+golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -618,8 +629,10 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0 h1:9sdfJOzWlkqPltHAuzT2Cp+yrBeY1KRVYgms8soxMwM=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -677,6 +690,8 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tsuru/client/apps.go
+++ b/tsuru/client/apps.go
@@ -648,7 +648,7 @@ Platform: {{.Platform}}
 Provisioner: {{ .Provisioner }}
 {{ end -}}
 {{if not .Routers -}}
-Router: {{.Router}}{{if .RouterOpts}} ({{.GetRouterOpts}}){{end}}
+Router:{{if .Router}} {{.Router}}{{if .RouterOpts}} ({{.GetRouterOpts}}){{end}}{{end}}
 {{end -}}
 Teams: {{.GetTeams}}
 Address: {{.Addr}}

--- a/tsuru/client/apps_test.go
+++ b/tsuru/client/apps_test.go
@@ -472,6 +472,7 @@ func (s *S) TestAppUpdate(c *check.C) {
 				"platform":     "python",
 				"tags":         []interface{}{"tag 1", "tag 2"},
 				"planoverride": map[string]interface{}{},
+				"metadata":     map[string]interface{}{},
 			})
 			return url && method
 		},
@@ -504,6 +505,7 @@ func (s *S) TestAppUpdateImageReset(c *check.C) {
 			c.Assert(result, check.DeepEquals, map[string]interface{}{
 				"imageReset":   true,
 				"planoverride": map[string]interface{}{},
+				"metadata":     map[string]interface{}{},
 			})
 			return url && method
 		},
@@ -536,6 +538,7 @@ func (s *S) TestAppUpdateWithoutTags(c *check.C) {
 			c.Assert(result, check.DeepEquals, map[string]interface{}{
 				"description":  "description",
 				"planoverride": map[string]interface{}{},
+				"metadata":     map[string]interface{}{},
 			})
 			return url && method
 		},
@@ -569,6 +572,7 @@ func (s *S) TestAppUpdateWithEmptyTag(c *check.C) {
 				"description":  "description",
 				"tags":         []interface{}{""},
 				"planoverride": map[string]interface{}{},
+				"metadata":     map[string]interface{}{},
 			})
 			return url && method
 		},
@@ -603,6 +607,7 @@ func (s *S) TestAppUpdateWithCPUAndMemory(c *check.C) {
 					"cpumilli": float64(100),
 					"memory":   float64(1 * 1024 * 1024 * 1024),
 				},
+				"metadata": map[string]interface{}{},
 			})
 			return url && method
 		},
@@ -2106,7 +2111,7 @@ Description:
 Tags:
 Repository: git@git.com:app.git
 Platform: assembly
-Router: 
+Router:
 Teams: tsuruzers
 Address: monster.tsuru.io
 Owner: myapp_owner

--- a/tsuru/client/metadata.go
+++ b/tsuru/client/metadata.go
@@ -1,0 +1,263 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/tsuru/gnuflag"
+	"github.com/tsuru/go-tsuruclient/pkg/client"
+	"github.com/tsuru/go-tsuruclient/pkg/tsuru"
+	"github.com/tsuru/tsuru/cmd"
+	appTypes "github.com/tsuru/tsuru/types/app"
+)
+
+const metadataSetValidationMessage = `You must specify metadata in the form "NAME=value" with the specified type.
+
+Example:
+
+  tsuru app-metadata-set -t label NAME=value OTHER_NAME="value with spaces" ANOTHER_NAME='using single quotes'
+  tsuru app-metadata-set -t annotation NAME=value OTHER_NAME="value with spaces" ANOTHER_NAME='using single quotes'
+
+`
+
+var allowedTypes = []string{"label", "annotation"}
+
+type MetadataGet struct {
+	cmd.GuessingCommand
+}
+
+func (c *MetadataGet) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "app-metadata-get",
+		Usage:   "app-metadata-get [-a/--app appname]",
+		Desc:    `Retrieves metadata for an application.`,
+		MinArgs: 0,
+	}
+}
+
+func (c *MetadataGet) Run(context *cmd.Context, client *cmd.Client) error {
+	appName, err := c.Guess()
+	if err != nil {
+		return err
+	}
+
+	u, err := cmd.GetURL(fmt.Sprintf("/apps/%s", appName))
+	if err != nil {
+		return err
+	}
+
+	request, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	defer response.Body.Close()
+
+	var a struct {
+		Metadata appTypes.Metadata
+	}
+	err = json.NewDecoder(response.Body).Decode(&a)
+	if err != nil {
+		return err
+	}
+	formatted := make([]string, 0, len(a.Metadata.Labels))
+	for _, v := range a.Metadata.Labels {
+		formatted = append(formatted, fmt.Sprintf("\t%s: %s", v.Name, v.Value))
+	}
+	sort.Strings(formatted)
+	fmt.Fprintln(context.Stdout, "Labels:")
+	fmt.Fprintln(context.Stdout, strings.Join(formatted, "\n"))
+
+	formatted = make([]string, 0, len(a.Metadata.Annotations))
+	for _, v := range a.Metadata.Annotations {
+		formatted = append(formatted, fmt.Sprintf("\t%s: %s", v.Name, v.Value))
+	}
+	sort.Strings(formatted)
+	fmt.Fprintln(context.Stdout, "Annotations:")
+	fmt.Fprintln(context.Stdout, strings.Join(formatted, "\n"))
+	return nil
+}
+
+type MetadataSet struct {
+	cmd.GuessingCommand
+	fs           *gnuflag.FlagSet
+	metadataType string
+	noRestart    bool
+}
+
+func (c *MetadataSet) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "app-metadata-set",
+		Usage:   "app-metadata-set <NAME=value> [NAME=value] ... [-a/--app appname] [-t/--type type]",
+		Desc:    `Sets metadata such as labels and annotations for an application.`,
+		MinArgs: 1,
+	}
+}
+
+func (c *MetadataSet) Flags() *gnuflag.FlagSet {
+	if c.fs == nil {
+		c.fs = c.GuessingCommand.Flags()
+		c.fs.StringVar(&c.metadataType, "type", "", "Metadata type: annotation or label")
+		c.fs.StringVar(&c.metadataType, "t", "", "Metadata type: annotation or label")
+		c.fs.BoolVar(&c.noRestart, "no-restart", false, "Sets metadata without restarting the application")
+	}
+	return c.fs
+}
+
+func (c *MetadataSet) Run(ctx *cmd.Context, cli *cmd.Client) error {
+	ctx.RawOutput()
+	appName := c.Flags().Lookup("app").Value.String()
+	if appName == "" {
+		return errors.New("Please use the -a/--app flag to specify which app you want to update.")
+	}
+
+	if len(ctx.Args) < 1 {
+		return errors.New(metadataSetValidationMessage)
+	}
+
+	if err := validateType(c.metadataType); err != nil {
+		return err
+	}
+
+	items := make([]tsuru.MetadataItem, len(ctx.Args))
+	for i := range ctx.Args {
+		parts := strings.SplitN(ctx.Args[i], "=", 2)
+		if len(parts) != 2 {
+			return errors.New(metadataSetValidationMessage)
+		}
+		items[i] = tsuru.MetadataItem{Name: parts[0], Value: parts[1]}
+	}
+
+	var metadata tsuru.Metadata
+	switch c.metadataType {
+	case "label":
+		metadata.Labels = items
+	case "annotation":
+		metadata.Annotations = items
+	}
+
+	apiClient, err := client.ClientFromEnvironment(&tsuru.Configuration{
+		HTTPClient: cli.HTTPClient,
+	})
+	if err != nil {
+		return err
+	}
+
+	updateApp := tsuru.UpdateApp{
+		Metadata:  metadata,
+		NoRestart: c.noRestart,
+	}
+
+	response, err := apiClient.AppApi.AppUpdate(context.TODO(), appName, updateApp)
+	if err != nil {
+		return err
+	}
+
+	err = cmd.StreamJSONResponse(ctx.Stdout, response)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(ctx.Stdout, "App %q has been updated!\n", appName)
+	return nil
+}
+
+func validateType(t string) error {
+	t = strings.ToLower(t)
+	for _, allowed := range allowedTypes {
+		if t == allowed {
+			return nil
+		}
+	}
+	return errors.New("A type is required: label or annotation")
+}
+
+type MetadataUnset struct {
+	cmd.GuessingCommand
+	fs           *gnuflag.FlagSet
+	metadataType string
+	noRestart    bool
+}
+
+func (c *MetadataUnset) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "app-metadata-unset",
+		Usage:   "app-metadata-unset <NAME> [NAME] ... [-a/--app appname] [-t/--type type]",
+		Desc:    `Unsets metadata such as labels and annotations for an application.`,
+		MinArgs: 1,
+	}
+}
+
+func (c *MetadataUnset) Flags() *gnuflag.FlagSet {
+	if c.fs == nil {
+		c.fs = c.GuessingCommand.Flags()
+		c.fs.StringVar(&c.metadataType, "type", "", "Metadata type: annotation or label")
+		c.fs.StringVar(&c.metadataType, "t", "", "Metadata type: annotation or label")
+		c.fs.BoolVar(&c.noRestart, "no-restart", false, "Sets metadata without restarting the application")
+	}
+	return c.fs
+}
+
+func (c *MetadataUnset) Run(ctx *cmd.Context, cli *cmd.Client) error {
+	ctx.RawOutput()
+	appName := c.Flags().Lookup("app").Value.String()
+	if appName == "" {
+		return errors.New("Please use the -a/--app flag to specify which app you want to update.")
+	}
+
+	if len(ctx.Args) < 1 {
+		return errors.New(metadataSetValidationMessage)
+	}
+
+	if err := validateType(c.metadataType); err != nil {
+		return err
+	}
+
+	items := make([]tsuru.MetadataItem, len(ctx.Args))
+	for i := range ctx.Args {
+		items[i] = tsuru.MetadataItem{Name: ctx.Args[i], Delete: true}
+	}
+
+	var metadata tsuru.Metadata
+	switch c.metadataType {
+	case "label":
+		metadata.Labels = items
+	case "annotation":
+		metadata.Annotations = items
+	}
+
+	apiClient, err := client.ClientFromEnvironment(&tsuru.Configuration{
+		HTTPClient: cli.HTTPClient,
+	})
+	if err != nil {
+		return err
+	}
+
+	updateApp := tsuru.UpdateApp{
+		Metadata:  metadata,
+		NoRestart: c.noRestart,
+	}
+
+	response, err := apiClient.AppApi.AppUpdate(context.TODO(), appName, updateApp)
+	if err != nil {
+		return err
+	}
+
+	err = cmd.StreamJSONResponse(ctx.Stdout, response)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(ctx.Stdout, "App %q has been updated!\n", appName)
+	return nil
+}

--- a/tsuru/client/metadata.go
+++ b/tsuru/client/metadata.go
@@ -20,8 +20,8 @@ const metadataSetValidationMessage = `You must specify metadata in the form "NAM
 
 Example:
 
-  tsuru app-metadata-set -t label NAME=value OTHER_NAME="value with spaces" ANOTHER_NAME='using single quotes'
-  tsuru app-metadata-set -t annotation NAME=value OTHER_NAME="value with spaces" ANOTHER_NAME='using single quotes'
+  tsuru app-metadata-set -a APPNAME -t label NAME=value OTHER_NAME="value with spaces" ANOTHER_NAME='using single quotes'
+  tsuru app-metadata-set -a APPNAME -t annotation NAME=value OTHER_NAME="value with spaces" ANOTHER_NAME='using single quotes'
 
 `
 

--- a/tsuru/client/metadata_test.go
+++ b/tsuru/client/metadata_test.go
@@ -1,0 +1,258 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/tsuru/tsuru/cmd"
+	"github.com/tsuru/tsuru/cmd/cmdtest"
+	check "gopkg.in/check.v1"
+)
+
+func (s *S) TestMetadataGetInfo(c *check.C) {
+	c.Assert((&MetadataGet{}).Info(), check.NotNil)
+}
+
+func (s *S) TestMetadataGetRun(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	jsonResult := `{"metadata":{"annotations":[{"name":"my-annotation","value":"some long value"}],"labels":[{"name":"logging.globoi.com/backup","value":"true"}]}}`
+	result := "Labels:\n" +
+		"\tlogging.globoi.com/backup: true\n" +
+		"Annotations:\n" +
+		"\tmy-annotation: some long value\n"
+	context := cmd.Context{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	client := cmd.NewClient(&http.Client{Transport: &cmdtest.Transport{Message: jsonResult, Status: http.StatusOK}}, nil, manager)
+	command := MetadataGet{}
+	command.Flags().Parse(true, []string{"-a", "someapp"})
+	err := command.Run(&context, client)
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout.String(), check.Equals, result)
+}
+
+func (s *S) TestMetadataSetInfo(c *check.C) {
+	c.Assert((&MetadataSet{}).Info(), check.NotNil)
+}
+
+func (s *S) TestMetadataSetRunWithLabel(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"test.tsuru.io/label=some-value"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	expectedOut := "App \"someapp\" has been updated!\n"
+
+	trans := &cmdtest.ConditionalTransport{
+		Transport: cmdtest.Transport{Status: http.StatusOK},
+		CondFunc: func(req *http.Request) bool {
+			url := strings.HasSuffix(req.URL.Path, "/apps/someapp")
+			method := req.Method == "PUT"
+			data, err := ioutil.ReadAll(req.Body)
+			c.Assert(err, check.IsNil)
+
+			var payload map[string]interface{}
+			err = json.Unmarshal(data, &payload)
+			c.Assert(err, check.IsNil)
+			c.Assert(payload, check.DeepEquals, map[string]interface{}{
+				"planoverride": map[string]interface{}{},
+				"metadata": map[string]interface{}{
+					"labels": []interface{}{map[string]interface{}{"name": "test.tsuru.io/label", "value": "some-value"}},
+				},
+			})
+			return url && method
+		},
+	}
+	client := cmd.NewClient(&http.Client{Transport: trans}, nil, manager)
+
+	command := MetadataSet{}
+	command.Flags().Parse(true, []string{"-a", "someapp", "-t", "label"})
+	err := command.Run(&context, client)
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout.String(), check.Equals, expectedOut)
+}
+
+func (s *S) TestMetadataSetRunWithAnnotations(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"test.tsuru.io/label=some-value, that is really long"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	expectedOut := "App \"someapp\" has been updated!\n"
+
+	trans := &cmdtest.ConditionalTransport{
+		Transport: cmdtest.Transport{Status: http.StatusOK},
+		CondFunc: func(req *http.Request) bool {
+			url := strings.HasSuffix(req.URL.Path, "/apps/someapp")
+			method := req.Method == "PUT"
+			data, err := ioutil.ReadAll(req.Body)
+			c.Assert(err, check.IsNil)
+
+			var payload map[string]interface{}
+			err = json.Unmarshal(data, &payload)
+			c.Assert(err, check.IsNil)
+			c.Assert(payload, check.DeepEquals, map[string]interface{}{
+				"planoverride": map[string]interface{}{},
+				"metadata": map[string]interface{}{
+					"annotations": []interface{}{map[string]interface{}{"name": "test.tsuru.io/label", "value": "some-value, that is really long"}},
+				},
+			})
+			return url && method
+		},
+	}
+	client := cmd.NewClient(&http.Client{Transport: trans}, nil, manager)
+
+	command := MetadataSet{}
+	command.Flags().Parse(true, []string{"-a", "someapp", "-t", "annotation"})
+	err := command.Run(&context, client)
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout.String(), check.Equals, expectedOut)
+}
+
+func (s *S) TestMetadataSetFailsWithoutType(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"test.tsuru.io/label=some-value"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	trans := &cmdtest.ConditionalTransport{
+		Transport: cmdtest.Transport{Status: http.StatusOK},
+	}
+	client := cmd.NewClient(&http.Client{Transport: trans}, nil, manager)
+
+	command := MetadataSet{}
+	command.Flags().Parse(true, []string{"-a", "someapp"})
+	err := command.Run(&context, client)
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, "A type is required: label or annotation")
+}
+
+func (s *S) TestMetadateSetSupportsNoRestart(c *check.C) {
+	command := MetadataSet{}
+	flagset := command.Flags()
+	flagset.Parse(true, []string{"--no-restart"})
+	noRestart := flagset.Lookup("no-restart")
+	c.Check(noRestart, check.NotNil)
+	c.Check(noRestart.Name, check.Equals, "no-restart")
+	c.Check(noRestart.Value.String(), check.Equals, "true")
+	c.Check(noRestart.DefValue, check.Equals, "false")
+}
+
+func (s *S) TestMetadataUnsetInfo(c *check.C) {
+	c.Assert((&MetadataUnset{}).Info(), check.NotNil)
+}
+
+func (s *S) TestMetadataUnsetRunWithLabel(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"test.tsuru.io/label"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	expectedOut := "App \"someapp\" has been updated!\n"
+
+	trans := &cmdtest.ConditionalTransport{
+		Transport: cmdtest.Transport{Status: http.StatusOK},
+		CondFunc: func(req *http.Request) bool {
+			url := strings.HasSuffix(req.URL.Path, "/apps/someapp")
+			method := req.Method == "PUT"
+			data, err := ioutil.ReadAll(req.Body)
+			c.Assert(err, check.IsNil)
+
+			var payload map[string]interface{}
+			err = json.Unmarshal(data, &payload)
+			c.Assert(err, check.IsNil)
+			c.Assert(payload, check.DeepEquals, map[string]interface{}{
+				"planoverride": map[string]interface{}{},
+				"metadata": map[string]interface{}{
+					"labels": []interface{}{map[string]interface{}{"name": "test.tsuru.io/label", "delete": true}},
+				},
+			})
+			return url && method
+		},
+	}
+	client := cmd.NewClient(&http.Client{Transport: trans}, nil, manager)
+
+	command := MetadataUnset{}
+	command.Flags().Parse(true, []string{"-a", "someapp", "-t", "label"})
+	err := command.Run(&context, client)
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout.String(), check.Equals, expectedOut)
+}
+
+func (s *S) TestMetadataUnsetRunWithAnnotations(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"test.tsuru.io/label"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	expectedOut := "App \"someapp\" has been updated!\n"
+
+	trans := &cmdtest.ConditionalTransport{
+		Transport: cmdtest.Transport{Status: http.StatusOK},
+		CondFunc: func(req *http.Request) bool {
+			url := strings.HasSuffix(req.URL.Path, "/apps/someapp")
+			method := req.Method == "PUT"
+			data, err := ioutil.ReadAll(req.Body)
+			c.Assert(err, check.IsNil)
+
+			var payload map[string]interface{}
+			err = json.Unmarshal(data, &payload)
+			c.Assert(err, check.IsNil)
+			c.Assert(payload, check.DeepEquals, map[string]interface{}{
+				"planoverride": map[string]interface{}{},
+				"metadata": map[string]interface{}{
+					"annotations": []interface{}{map[string]interface{}{"name": "test.tsuru.io/label", "delete": true}},
+				},
+			})
+			return url && method
+		},
+	}
+	client := cmd.NewClient(&http.Client{Transport: trans}, nil, manager)
+
+	command := MetadataUnset{}
+	command.Flags().Parse(true, []string{"-a", "someapp", "-t", "annotation"})
+	err := command.Run(&context, client)
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout.String(), check.Equals, expectedOut)
+}
+
+func (s *S) TestMetadataUnsetFailsWithoutType(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"test.tsuru.io/label"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	trans := &cmdtest.ConditionalTransport{
+		Transport: cmdtest.Transport{Status: http.StatusOK},
+	}
+	client := cmd.NewClient(&http.Client{Transport: trans}, nil, manager)
+
+	command := MetadataUnset{}
+	command.Flags().Parse(true, []string{"-a", "someapp"})
+	err := command.Run(&context, client)
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, "A type is required: label or annotation")
+}
+
+func (s *S) TestMetadateUnsetSupportsNoRestart(c *check.C) {
+	command := MetadataUnset{}
+	flagset := command.Flags()
+	flagset.Parse(true, []string{"--no-restart"})
+	noRestart := flagset.Lookup("no-restart")
+	c.Check(noRestart, check.NotNil)
+	c.Check(noRestart.Name, check.Equals, "no-restart")
+	c.Check(noRestart.Value.String(), check.Equals, "true")
+	c.Check(noRestart.DefValue, check.Equals, "false")
+}


### PR DESCRIPTION
Adds support for managing labels and annotations with the following commands:
- *app-metadata-get*
- *app-metadata-set*
- *app-metadata-unset*

