### PR TITLE
add support for configs (offline state)

### DIFF
--- a/tsuru/config/config.go
+++ b/tsuru/config/config.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/tsuru/tsuru/cmd"
+)
+
+var (
+	config        *ConfigType
+	configPath    string        = cmd.JoinWithUserDir(".tsuru", "config.json")
+	SchemaVersion string        = "0.1"
+	stdout        io.ReadWriter = os.Stdout
+	stderr        io.ReadWriter = os.Stderr
+)
+
+type ConfigType struct {
+	SchemaVersion string
+	LastUpdate    time.Time
+	hasChanges    bool
+}
+
+func newDefaultConf() *ConfigType {
+	return &ConfigType{
+		SchemaVersion: SchemaVersion,
+		LastUpdate:    time.Now().UTC(),
+		hasChanges:    true,
+	}
+}
+
+func bootstrapConfig() *ConfigType {
+	file, err := filesystem().Open(configPath)
+	if err != nil {
+		return newDefaultConf()
+	}
+	defer file.Close()
+
+	nowTimeStr := time.Now().UTC().Format("2006-01-02_15:04:05")
+	backupFilePath := configPath + "." + nowTimeStr + ".bak"
+
+	rawContent, err := io.ReadAll(file)
+	if err != nil {
+		fmt.Fprintf(stderr, "Could not read %q: %v\nContinuing without config", configPath, err)
+		return nil
+	}
+
+	config := ConfigType{}
+	if err := json.Unmarshal(rawContent, &config); err != nil {
+		fmt.Fprintf(stderr, "Error parsing %q: %v\n", configPath, err)
+		fmt.Fprintf(stderr, "Backing up current file to %q. A new configuration will be saved.\n", backupFilePath)
+		filesystem().Rename(configPath, backupFilePath)
+		return newDefaultConf()
+	}
+	return &config
+}
+
+func Config() *ConfigType {
+	if config == nil {
+		config = bootstrapConfig()
+	}
+	return config
+}
+
+func (c *ConfigType) HasChanges() bool {
+	if c != nil && c.hasChanges {
+		return true
+	}
+	return false
+}
+
+func (c *ConfigType) SaveChanges() error {
+	if !c.HasChanges() {
+		return nil
+	}
+
+	file, err := filesystem().OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("Could not open file %q for write: %w", configPath, err)
+	}
+	jsonData, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Could not convert config to JSON: %w", err)
+	}
+	_, err = file.Write(jsonData)
+	if err != nil {
+		return fmt.Errorf("Got errors when saving config: %w", err)
+	}
+	return nil
+}

--- a/tsuru/config/config.go
+++ b/tsuru/config/config.go
@@ -76,7 +76,8 @@ func (c *ConfigType) hasChanges() bool {
 	return c.LastUpdate.Before(c.lastChanges)
 }
 
-func (c *ConfigType) SaveChanges() error {
+func SaveChanges() error {
+	c := getConfig()
 	if !c.hasChanges() {
 		return nil
 	}

--- a/tsuru/config/config_test.go
+++ b/tsuru/config/config_test.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/tsuru/tsuru/fs/fstest"
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestBoostrapConfigNoConfig(c *check.C) {
+	fsystem = &fstest.RecordingFs{}
+	stat, err := fsystem.Stat(configPath)
+	errorMsg := err.Error()
+	c.Assert(stat, check.IsNil)
+	c.Assert(
+		(errorMsg == "The system cannot find the file specified." ||
+			errorMsg == "no such file or directory"),
+		check.Equals,
+		true,
+		check.Commentf("Got error: %v", err))
+
+	conf := bootstrapConfig()
+	c.Assert(conf, check.NotNil)
+	expected := newDefaultConf()
+	expected.LastUpdate = conf.LastUpdate
+	c.Assert(conf, check.DeepEquals, expected)
+}
+
+func (s *S) TestBoostrapConfigFromFile(c *check.C) {
+	fsystem = &fstest.RecordingFs{}
+	f, _ := fsystem.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	fmt.Fprintf(f, `{
+  "SchemaVersion": "6.6.6",
+  "LastUpdate": "2020-12-25T16:00:59Z"
+}`)
+	f.Close()
+
+	conf := bootstrapConfig()
+	c.Assert(conf, check.NotNil)
+	expected := &ConfigType{
+		SchemaVersion: "6.6.6",
+		LastUpdate:    time.Date(2020, 12, 25, 16, 00, 59, 0, time.UTC),
+		hasChanges:    false,
+	}
+	c.Assert(conf, check.DeepEquals, expected)
+}
+
+func (s *S) TestBoostrapConfigWrongFormatBackupFile(c *check.C) {
+	stdout = &bytes.Buffer{}
+	stderr = &bytes.Buffer{}
+	fsystem = &fstest.RecordingFs{}
+
+	f, _ := fsystem.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	f.WriteString("wrong format")
+	f.Close()
+	nowTimeStr := time.Now().UTC().Format("2006-01-02_15:04:05")
+	backupConfigPath := configPath + "." + nowTimeStr + ".bak"
+
+	conf := bootstrapConfig()
+	c.Assert(conf, check.NotNil)
+	expected := newDefaultConf()
+	expected.LastUpdate = conf.LastUpdate
+	c.Assert(conf, check.DeepEquals, expected)
+
+	stdoutBytes, err := io.ReadAll(stdout)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(stdoutBytes), check.DeepEquals, "")
+	stderrBytes, err := io.ReadAll(stderr)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(string(stderrBytes), "Error parsing "), check.Equals, true, check.Commentf("Got: %s", string(stderrBytes)))
+	c.Assert(strings.Contains(string(stderrBytes), "Backing up current file to "), check.Equals, true, check.Commentf("Got: %s", string(stderrBytes)))
+	c.Assert(strings.Contains(string(stderrBytes), "A new configuration will be saved"), check.Equals, true, check.Commentf("Got: %s", string(stderrBytes)))
+
+	stat, err := fsystem.Stat(backupConfigPath)
+	c.Assert(err, check.IsNil)
+	c.Assert(stat, check.NotNil)
+}
+
+func (s *S) TestConfig(c *check.C) {
+	config = nil
+	conf1 := Config()
+	c.Assert(conf1, check.NotNil)
+	conf2 := Config()
+	c.Assert(conf1, check.Equals, conf2)
+}
+
+func (s *S) TestHasChanges(c *check.C) {
+	conf := &ConfigType{
+		hasChanges: false,
+	}
+	c.Assert(conf.HasChanges(), check.Equals, false)
+
+	conf = &ConfigType{
+		hasChanges: true,
+	}
+	c.Assert(conf.HasChanges(), check.Equals, true)
+
+	conf = nil
+	c.Assert(conf.HasChanges(), check.Equals, false)
+}
+
+func (s *S) TestSaveChanges(c *check.C) {
+	fsystem = &fstest.RecordingFs{}
+	f, _ := fsystem.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	originalContent := `{
+  "SchemaVersion": "6.6.6",
+  "LastUpdate": "2020-12-25T16:00:59Z"
+}`
+	fmt.Fprint(f, originalContent)
+	f.Close()
+
+	conf := bootstrapConfig()
+	c.Assert(conf, check.NotNil)
+
+	now := time.Now().UTC()
+	conf.SchemaVersion = "6.6.7"
+	conf.LastUpdate = now
+	conf.SaveChanges() // no changes
+
+	f, _ = fsystem.Open(configPath)
+	bytesRead, err := io.ReadAll(f)
+	f.Close()
+	c.Assert(err, check.IsNil)
+	c.Assert(string(bytesRead), check.Equals, originalContent)
+
+	conf.hasChanges = true
+	conf.SaveChanges()
+	f, _ = fsystem.Open(configPath)
+	bytesRead, err = io.ReadAll(f)
+	f.Close()
+	c.Assert(err, check.IsNil)
+	c.Assert(string(bytesRead), check.Equals, fmt.Sprintf(`{
+  "SchemaVersion": "6.6.7",
+  "LastUpdate": "%s"
+}`, now.Format(time.RFC3339Nano)),
+	)
+}

--- a/tsuru/config/config_test.go
+++ b/tsuru/config/config_test.go
@@ -125,13 +125,13 @@ func (s *S) TestSaveChanges(c *check.C) {
 	fmt.Fprint(f, originalContent)
 	f.Close()
 
-	conf := bootstrapConfig()
-	c.Assert(conf, check.NotNil)
+	config = bootstrapConfig()
+	c.Assert(config, check.NotNil)
 
 	now := time.Now().UTC()
-	conf.SchemaVersion = "6.6.7"
-	conf.LastUpdate = now
-	conf.SaveChanges() // no changes
+	config.SchemaVersion = "6.6.7"
+	config.LastUpdate = now
+	SaveChanges() // no changes
 
 	f, _ = fsystem.Open(configPath)
 	bytesRead, err := io.ReadAll(f)
@@ -139,8 +139,8 @@ func (s *S) TestSaveChanges(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(string(bytesRead), check.Equals, originalContent)
 
-	conf.lastChanges = conf.LastUpdate.Add(10 * time.Millisecond)
-	conf.SaveChanges()
+	config.lastChanges = config.LastUpdate.Add(10 * time.Millisecond)
+	SaveChanges()
 	f, _ = fsystem.Open(configPath)
 	bytesRead, err = io.ReadAll(f)
 	f.Close()
@@ -150,4 +150,5 @@ func (s *S) TestSaveChanges(c *check.C) {
   "LastUpdate": "%s"
 }`, now.Format(time.RFC3339Nano)),
 	)
+	config = nil
 }

--- a/tsuru/config/filesystem.go
+++ b/tsuru/config/filesystem.go
@@ -1,0 +1,18 @@
+// Copyright 2016 tsuru-client authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package config
+
+import (
+	"github.com/tsuru/tsuru/fs"
+)
+
+var fsystem fs.Fs
+
+func filesystem() fs.Fs {
+	if fsystem == nil {
+		fsystem = fs.OsFs{}
+	}
+	return fsystem
+}

--- a/tsuru/config/filesystem_test.go
+++ b/tsuru/config/filesystem_test.go
@@ -1,0 +1,18 @@
+// Copyright 2016 tsuru-client authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package config
+
+import (
+	"github.com/tsuru/tsuru/fs"
+	"github.com/tsuru/tsuru/fs/fstest"
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestFileSystem(c *check.C) {
+	fsystem = &fstest.RecordingFs{}
+	c.Assert(filesystem(), check.DeepEquals, fsystem)
+	fsystem = nil
+	c.Assert(filesystem(), check.DeepEquals, fs.OsFs{})
+}

--- a/tsuru/config/suite_test.go
+++ b/tsuru/config/suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+type S struct{}
+
+var _ = check.Suite(&S{})
+
+func Test(t *testing.T) { check.TestingT(t) }

--- a/tsuru/main.go
+++ b/tsuru/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
 	"github.com/tsuru/tsuru-client/tsuru/admin"
 	"github.com/tsuru/tsuru-client/tsuru/client"
+	"github.com/tsuru/tsuru-client/tsuru/config"
 	"github.com/tsuru/tsuru/cmd"
 	"github.com/tsuru/tsuru/iaas/dockermachine"
 	_ "github.com/tsuru/tsuru/provision/docker/cmds"
@@ -237,6 +238,7 @@ func main() {
 			log.Fatalf("Error running driver: %s", err)
 		}
 	} else {
+		defer config.SaveChanges()
 		localbinary.CurrentBinaryIsDockerMachine = true
 		name := cmd.ExtractProgramName(os.Args[0])
 		m := buildManager(name)


### PR DESCRIPTION
Implementing base structure for storing state
```json
{
  "SchemaVersion": "0.1",
  "LastUpdate": "2020-12-25T16:00:59Z"
}
```

It shall be extended to something like this (format is still work in progress)

```json
{
  "SchemaVersion": "0.1",
  "LastUpdate": "2020-12-25T16:00:59Z",
  "AutoUpdate": {
    "LastCheck": "2020-12-25T16:00:59Z",
    "SnoozeUntil": "2025-12-25T16:00:59Z"
  },
  "plugins" : {
    "bundles": [
      "https://example.com/tsuru-plugin-bundle-1",
      "https://example.com/tsuru-plugin-bundle-2"
    ]
  } 
}
```

- [x] feature #170 
    - [x] reading config from ~/.tsuru/config.json
    - [x] creating config if does not exist
    - [x] saving config on program stop (with defer) 
        - [x] only writes to file if any change
    - [x] handle corner cases
        - [x] errors reading existing file (file exists but error when reading) - printError and continue without this feature (keep old behaviour)
        - [x] if cannot parse into JSON, makes a timed backup and resets config.json
- [x] tests
    - [x] TestBoostrapConfigNoConfig
    - [x] TestBoostrapConfigFromFile
    - [x] TestBoostrapConfigWrongFormatBackupFile
    - [x] TestConfig
    - [x] TestHasChanges
    - [x] TestSaveChanges

closes #170 