### PR TITLE
inject version at build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 bin
 docs
 misc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,25 @@
 FROM golang:1.16-alpine AS builder
 
-COPY . /go/src/github.com/tsuru/tsuru-client
+RUN apk add --update --no-cache \
+        gcc \
+        git \
+        make \
+        musl-dev \
+    && :
 
 WORKDIR /go/src/github.com/tsuru/tsuru-client
+COPY . /go/src/github.com/tsuru/tsuru-client
 
-RUN apk add --update gcc git make musl-dev && \
-    make build
+RUN ls -al . \
+    && git describe --tags \
+    && make build
 
 FROM alpine:3.9
-
-COPY --from=builder /go/src/github.com/tsuru/tsuru-client/bin/tsuru /bin/tsuru
 
 RUN apk update && \
     apk add --no-cache ca-certificates && \
     rm /var/cache/apk/*
+
+COPY --from=builder /go/src/github.com/tsuru/tsuru-client/bin/tsuru /bin/tsuru
 
 CMD ["tsuru"]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PYTHON := $(shell which python)
 
 GHR := $(shell which ghr)
 GITHUB_TOKEN := $(shell git config --global --get github.token || echo $$GITHUB_TOKEN)
+GIT_TAG_VER := $(shell git describe --tags || echo "dev")
 
 release:
 	@if [ ! $(version) ]; then \
@@ -23,9 +24,6 @@ release:
 	fi
 
 	@echo " ==> Releasing tsuru $(version) version."
-
-	@echo " ==> Replacing version string."
-	@sed -i "s/version = \".*\"/version = \"$(version)\"/g" tsuru/main.go
 
 	@echo " ==> Building binaries."
 	@./misc/build-all.sh
@@ -71,7 +69,7 @@ build-all:
 	./misc/build-all.sh
 
 build:
-	go build -o ./bin/tsuru ./tsuru
+	go build -ldflags "-s -w -X 'main.version=$(GIT_TAG_VER)'" -o ./bin/tsuru ./tsuru
 
 check-docs: build
 	./misc/check-all-cmds-docs.sh

--- a/goreleaser-rc.yml
+++ b/goreleaser-rc.yml
@@ -17,6 +17,12 @@ builds:
       goarch: 386
     - goos: windows
       goarch: arm64
+  env:
+    - CGO_ENABLED=0
+  flags:
+    - -trimpath
+  ldflags:
+    - -s -w -X=main.version={{.Version}}
 
 # Archive customization
 archives:

--- a/goreleaser-stable.yml
+++ b/goreleaser-stable.yml
@@ -17,6 +17,12 @@ builds:
       goarch: 386
     - goos: windows
       goarch: arm64
+  env:
+    - CGO_ENABLED=0
+  flags:
+    - -trimpath
+  ldflags:
+    - -s -w -X=main.version={{.Version}}
 
 # Archive customization
 archives:

--- a/tsuru/main.go
+++ b/tsuru/main.go
@@ -18,9 +18,12 @@ import (
 	_ "github.com/tsuru/tsuru/provision/docker/cmds"
 )
 
+var (
+	version = "dev" // overridden at build time
+)
+
 const (
-	version = "1.12.0"
-	header  = "Supported-Tsuru"
+	header = "Supported-Tsuru"
 )
 
 func buildManager(name string) *cmd.Manager {


### PR DESCRIPTION
Ensure consistent version, by injecting the version at build time.

The version is derived from the latest git tag.

Goreleaser is responsible for deriving it (during CI).
If built with `make build`, the version is from `git describe --tags`, which should be the same string if build the latest tag.

This also give us reproducible builds (in theory). 
To test it, run this from the latest tag (only after this commit is merged and published)
```
goreleaser release --config goreleaser-stable.yml --skip-publish --rm-dist --auto-snapshot
md5sum $(which tsuru) ./dist/tsuru_$(uname -s | awk '{print tolower($0)}')_$(uname -m)*/tsuru
```