### PR TITLE
feat: adding support for os/arch agnostic manifest url for plugin install

### DIFF
--- a/tsuru/client/plugin.go
+++ b/tsuru/client/plugin.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/tsuru/gnuflag"
@@ -27,6 +28,17 @@ import (
 type Plugin struct {
 	Name string `json:"name"`
 	URL  string `json:"url"`
+}
+
+type PluginManifest struct {
+	SchemaVersion  string                 `json:"SchemaVersion"`
+	Metadata       PluginManifestMetadata `json:"Metadata"`
+	URLPerPlatform map[string]string      `json:"UrlPerPlatform"`
+}
+
+type PluginManifestMetadata struct {
+	Name    string `json:"Name"`
+	Version string `json:"Version"`
 }
 
 func (p *Plugin) Validate() error {
@@ -61,7 +73,7 @@ func (c *PluginInstall) Run(context *cmd.Context, client *cmd.Client) error {
 	}
 	pluginName := context.Args[0]
 	pluginURL := context.Args[1]
-	if err := installPlugin(pluginName, pluginURL); err != nil {
+	if err := installPlugin(pluginName, pluginURL, 0); err != nil {
 		return fmt.Errorf("Error installing plugin %q: %w", pluginName, err)
 	}
 
@@ -69,7 +81,10 @@ func (c *PluginInstall) Run(context *cmd.Context, client *cmd.Client) error {
 	return nil
 }
 
-func installPlugin(pluginName, pluginURL string) error {
+func installPlugin(pluginName, pluginURL string, level int) error {
+	if level > 1 { // Avoid infinite recursion
+		return fmt.Errorf("Infinite Recursion detected, check if manifest.json is correct")
+	}
 	tmpDir, err := filesystem().MkdirTemp("", "")
 	if err != nil {
 		return fmt.Errorf("Could not create a tmpdir: %w", err)
@@ -86,6 +101,19 @@ func installPlugin(pluginName, pluginURL string) error {
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
+	}
+	if strings.Contains(resp.Header.Get("Content-Type"), "application/json") { // If manifest.json URL
+		manifest := PluginManifest{}
+		if err = json.Unmarshal(data, &manifest); err != nil {
+			return fmt.Errorf("Error unmarshalling manifest %s", err.Error())
+		}
+		platform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH) // get platform information
+		if url, ok := manifest.URLPerPlatform[platform]; ok {
+			return installPlugin(pluginName, url, level+1)
+		} else {
+			return fmt.Errorf("No plugin URL found for architecture: %s", platform)
+		}
+
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return fmt.Errorf("Invalid status code reading plugin: %d - %q", resp.StatusCode, string(data))
@@ -416,7 +444,7 @@ func (c *PluginBundle) Run(context *cmd.Context, client *cmd.Client) error {
 	var successfulPlugins []string
 	failedPlugins := make(map[string]string)
 	for _, plugin := range bundleManifest.Plugins {
-		if err := installPlugin(plugin.Name, plugin.URL); err != nil {
+		if err := installPlugin(plugin.Name, plugin.URL, 0); err != nil {
 			failedPlugins[plugin.Name] = fmt.Sprintf("%v", err)
 		} else {
 			successfulPlugins = append(successfulPlugins, plugin.Name)

--- a/tsuru/client/plugin_test.go
+++ b/tsuru/client/plugin_test.go
@@ -6,6 +6,7 @@ package client
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -22,6 +23,57 @@ import (
 
 func (s *S) TestPluginInstallInfo(c *check.C) {
 	c.Assert(PluginInstall{}.Info(), check.NotNil)
+}
+
+func (s *S) TestPluginInstallWithManifest(c *check.C) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "fakeplugin")
+	}))
+	defer ts.Close()
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		urls := make(map[string]string)
+		urls["darwin/amd64"] = ts.URL
+		urls["darwin/arm64"] = ts.URL
+		urls["linux/amd64"] = ts.URL
+		urls["linux/arm64"] = ts.URL
+		urls["linux/386"] = ts.URL
+		urls["windows/amd64"] = ts.URL
+		urls["windows/386"] = ts.URL
+		manifest := PluginManifest{SchemaVersion: "1.0", Metadata: PluginManifestMetadata{Name: "rpaasv2", Version: "0.33.1"}, URLPerPlatform: urls}
+		jsonResp, err := json.Marshal(manifest)
+		c.Assert(err, check.IsNil)
+		w.Write(jsonResp)
+	}))
+
+	defer ts2.Close()
+	rfs := fstest.RecordingFs{}
+	fsystem = &rfs
+	defer func() {
+		fsystem = nil
+	}()
+	var stdout bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"myplugin", ts2.URL},
+		Stdout: &stdout,
+	}
+	client := cmd.NewClient(&http.Client{}, nil, manager)
+	command := PluginInstall{}
+	err := command.Run(&context, client)
+	c.Assert(err, check.IsNil)
+	pluginsPath := cmd.JoinWithUserDir(".tsuru", "plugins")
+	hasAction := rfs.HasAction(fmt.Sprintf("mkdirall %s with mode 0755", pluginsPath))
+	c.Assert(hasAction, check.Equals, true)
+	pluginPath := cmd.JoinWithUserDir(".tsuru", "plugins", "myplugin")
+	hasAction = rfs.HasAction(fmt.Sprintf("openfile %s with mode 0755", pluginPath))
+	c.Assert(hasAction, check.Equals, true)
+	f, err := rfs.Open(pluginPath)
+	c.Assert(err, check.IsNil)
+	data, err := ioutil.ReadAll(f)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(data), check.Equals, "fakeplugin\n")
+	expected := `Plugin "myplugin" successfully installed!` + "\n"
+	c.Assert(stdout.String(), check.Equals, expected)
 }
 
 func (s *S) TestPluginInstall(c *check.C) {


### PR DESCRIPTION
Closes #172

This PR aims to introduce support for os/architecture agnostic manifest URL for plugin installation. It will utilize the GOOS and GOARCH variables in order to find the correspondent URL in order to download the plugin.

It also utilizes the Content-Type from the response in order to identify if it's a manifest file or an actual binary. Also added a validation to avoid infinite recursive calls.

Unsure if this implementation works with plugin bundle install, but believe it would.

Added a single unit test for a plugin install utilizing manifest file, feel free to suggest new cases to test, wanted to get a first input beforehand :) 

