### PR TITLE
feat(app-deploy): support deploy with dockerfile

### DIFF
--- a/tsuru/client/archiver.go
+++ b/tsuru/client/archiver.go
@@ -110,7 +110,7 @@ func (a *archiver) archive(tw *tar.Writer, filesOnly bool, paths []string) error
 			return fmt.Errorf("failed to get the absolute filename of %q: %w", path, err)
 		}
 
-		if !strings.HasPrefix(abs, workingDir) {
+		if !strings.HasPrefix((abs + string(os.PathSeparator)), (workingDir + string(os.PathSeparator))) {
 			fmt.Fprintf(a.stderr, "WARNING: skipping file %q since you cannot add files outside the current directory\n", path)
 			continue
 		}

--- a/tsuru/client/archiver.go
+++ b/tsuru/client/archiver.go
@@ -26,7 +26,15 @@ type ArchiveOptions struct {
 	Stderr           io.Writer // defaults to io.Discard
 }
 
-func Archiver(dst io.Writer, filesOnly bool, paths []string, opts ArchiveOptions) error {
+func DefaultArchiveOptions(w io.Writer) ArchiveOptions {
+	return ArchiveOptions{
+		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
+		IgnoreFiles:      []string{".gitignore"},
+		Stderr:           w,
+	}
+}
+
+func Archive(dst io.Writer, filesOnly bool, paths []string, opts ArchiveOptions) error {
 	if dst == nil {
 		return fmt.Errorf("destination cannot be nil")
 	}

--- a/tsuru/client/archiver.go
+++ b/tsuru/client/archiver.go
@@ -1,0 +1,225 @@
+// Copyright 2023 tsuru-client authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gitignore "github.com/sabhiram/go-gitignore"
+)
+
+type ArchiveOptions struct {
+	CompressionLevel *int      // defaults to default compression "-1"
+	IgnoreFiles      []string  // default to none
+	Stderr           io.Writer // defaults to io.Discard
+}
+
+func Archiver(dst io.Writer, filesOnly bool, paths []string, opts ArchiveOptions) error {
+	if dst == nil {
+		return fmt.Errorf("destination cannot be nil")
+	}
+
+	if len(paths) == 0 {
+		return fmt.Errorf("paths cannot be empty")
+	}
+
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
+
+	var ignoreLines []string
+	for _, ignoreFile := range opts.IgnoreFiles {
+		data, err := os.ReadFile(ignoreFile)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to read ignore file %q: %w", ignoreFile, err)
+		}
+
+		fmt.Fprintf(opts.Stderr, "Using pattern(s) from %q to include/exclude files...\n", ignoreFile)
+
+		ignoreLines = append(ignoreLines, strings.Split(string(data), "\n")...)
+	}
+
+	ignore, err := gitignore.CompileIgnoreLines(ignoreLines...)
+	if err != nil {
+		return fmt.Errorf("failed to compile all ignore patterns: %w", err)
+	}
+
+	if opts.CompressionLevel == nil {
+		opts.CompressionLevel = func(n int) *int { return &n }(gzip.DefaultCompression)
+	}
+
+	zw, err := gzip.NewWriterLevel(dst, *opts.CompressionLevel)
+	if err != nil {
+		return err
+	}
+	defer zw.Close()
+
+	tw := tar.NewWriter(zw)
+	defer tw.Close()
+
+	a := &archiver{
+		ignore: *ignore,
+		stderr: opts.Stderr,
+	}
+
+	return a.archive(tw, filesOnly, paths)
+}
+
+type archiver struct {
+	ignore gitignore.GitIgnore
+	stderr io.Writer
+}
+
+func (a *archiver) archive(tw *tar.Writer, filesOnly bool, paths []string) error {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current directory: %w", err)
+	}
+
+	var added int
+
+	for _, path := range paths {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return fmt.Errorf("failed to get the absolute filename of %q: %w", path, err)
+		}
+
+		if !strings.HasPrefix(abs, workingDir) {
+			fmt.Fprintf(a.stderr, "WARNING: skipping %q since you cannot add files from outside of the current diretory %q\n", path, workingDir)
+			continue
+		}
+
+		fi, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		var n int
+		if fi.IsDir() {
+			n, err = a.addDir(tw, filesOnly, path, fi)
+			if err != nil {
+				return err
+			}
+
+			added += n
+			continue
+		}
+
+		n, err = a.addFile(tw, filesOnly, path, fi)
+		if err != nil {
+			return err
+		}
+
+		added += n
+	}
+
+	if added == 0 {
+		return fmt.Errorf("no files eligible to upload")
+	}
+
+	return nil
+}
+
+func (a *archiver) addFile(tw *tar.Writer, filesOnly bool, filename string, fi os.FileInfo) (int, error) {
+	isDir, isRegular, isSymlink := fi.IsDir(), fi.Mode().IsRegular(), fi.Mode()&os.ModeSymlink == os.ModeSymlink
+
+	if !isDir && !isRegular && !isSymlink { // neither dir, regular nor symlink
+		fmt.Fprintf(a.stderr, "WARNING: Skipping file %q due to unsupported file type.\n", filename)
+		return 0, nil
+	}
+
+	if isDir && filesOnly { // there's no need to create dirs in files only
+		return 0, nil
+	}
+
+	if a.ignore.MatchesPath(filename) {
+		fmt.Fprintf(a.stderr, "File %q matches with some pattern provided in the ignore file... skipping it.\n", filename)
+		return 0, nil
+	}
+
+	var linkname string
+	if isSymlink {
+		target, err := os.Readlink(filename)
+		if err != nil {
+			return 0, err
+		}
+
+		linkname = target
+	}
+
+	h, err := tar.FileInfoHeader(fi, linkname)
+	if err != nil {
+		return 0, err
+	}
+
+	if !filesOnly { // should preserve the directory tree
+		h.Name = filename
+	}
+
+	if strings.TrimRight(h.Name, string(os.PathSeparator)) == "." { // skipping root dir
+		return 0, nil
+	}
+
+	if err = tw.WriteHeader(h); err != nil {
+		return 0, err
+	}
+
+	if isDir || isSymlink { // there's no data to copy in dir or symlink
+		return 1, nil
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	written, err := io.CopyN(tw, f, h.Size)
+	if err != nil {
+		return 0, err
+	}
+
+	if written < h.Size {
+		return 0, io.ErrShortWrite
+	}
+
+	return 1, nil
+}
+
+func (a *archiver) addDir(tw *tar.Writer, filesOnly bool, path string, fi os.FileInfo) (int, error) {
+	var added int
+	return added, filepath.WalkDir(path, fs.WalkDirFunc(func(path string, dentry fs.DirEntry, err error) error {
+		if err != nil { // fail fast
+			return err
+		}
+
+		fi, err := dentry.Info()
+		if err != nil {
+			return err
+		}
+
+		var n int
+		n, err = a.addFile(tw, filesOnly, path, fi)
+		if err != nil {
+			return err
+		}
+
+		added += n
+
+		return nil
+	}))
+}

--- a/tsuru/client/archiver.go
+++ b/tsuru/client/archiver.go
@@ -29,7 +29,7 @@ type ArchiveOptions struct {
 func DefaultArchiveOptions(w io.Writer) ArchiveOptions {
 	return ArchiveOptions{
 		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
-		IgnoreFiles:      []string{".gitignore"},
+		IgnoreFiles:      []string{".tsuruignore"},
 		Stderr:           w,
 	}
 }

--- a/tsuru/client/archiver_test.go
+++ b/tsuru/client/archiver_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 tsuru-client authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"testing"
+
+	check "gopkg.in/check.v1"
+)
+
+func extractFiles(t *testing.T, c *check.C, r io.Reader) (m []miniFile) {
+	t.Helper()
+
+	gzr, err := gzip.NewReader(r)
+	c.Assert(err, check.IsNil)
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		h, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		c.Assert(err, check.IsNil)
+
+		var data []byte
+
+		if h.Typeflag == tar.TypeReg || h.Typeflag == tar.TypeRegA {
+			var b bytes.Buffer
+			written, err := io.CopyN(&b, tr, h.Size)
+			c.Assert(err, check.IsNil)
+			c.Assert(written, check.Equals, h.Size)
+			data = b.Bytes()
+		}
+
+		m = append(m, miniFile{
+			Name:     h.Name,
+			Linkname: h.Linkname,
+			Type:     h.Typeflag,
+			Data:     data,
+		})
+	}
+
+	return m
+}
+
+type miniFile struct {
+	Name     string
+	Linkname string
+	Type     byte
+	Data     []byte
+}

--- a/tsuru/client/archiver_test.go
+++ b/tsuru/client/archiver_test.go
@@ -1,0 +1,210 @@
+// Copyright 2023 tsuru-client authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	check "gopkg.in/check.v1"
+)
+
+func (s *S) TestArchive_NoDestination(c *check.C) {
+	err := Archiver(nil, false, nil, ArchiveOptions{})
+	c.Assert(err, check.ErrorMatches, "destination cannot be nil")
+}
+
+func (s *S) TestArchive_NoPaths(c *check.C) {
+	err := Archiver(io.Discard, false, nil, ArchiveOptions{})
+	c.Assert(err, check.ErrorMatches, "paths cannot be empty")
+
+	err = Archiver(io.Discard, false, []string{}, ArchiveOptions{})
+	c.Assert(err, check.ErrorMatches, "paths cannot be empty")
+}
+
+func (s *S) TestArchive_FileOutsideOfCurrentDir(c *check.C) {
+	var stderr bytes.Buffer
+	err := Archiver(io.Discard, false, []string{"../../../../var/www/html"}, ArchiveOptions{Stderr: &stderr})
+	c.Assert(err, check.ErrorMatches, "missing files to archive")
+	c.Assert(stderr.String(), check.Matches, `(?s).*WARNING: skipping file "\.\.\/\.\.\/\.\.\/\.\.\/var\/www\/html" since you cannot add files outside the current directory.*`)
+}
+
+func (s *S) TestArchive_PassingWholeDir(c *check.C) {
+	workingDir, err := os.Getwd()
+	c.Assert(err, check.IsNil)
+
+	defer func() { os.Chdir(workingDir) }()
+
+	err = os.Chdir(filepath.Join(workingDir, "./testdata/deploy/"))
+	c.Assert(err, check.IsNil)
+
+	var b bytes.Buffer
+
+	err = Archiver(&b, false, []string{"."}, ArchiveOptions{})
+	c.Assert(err, check.IsNil)
+
+	got := extractFiles(s.t, c, &b)
+	expected := []miniFile{
+		{Name: "directory", Type: tar.TypeDir},
+		{Name: "directory/file.txt", Type: tar.TypeReg, Data: []byte("wat\n")},
+		{Name: "file1.txt", Type: tar.TypeReg, Data: []byte("something happened\n")},
+		{Name: "file2.txt", Type: tar.TypeReg, Data: []byte("twice\n")},
+	}
+	c.Assert(got, check.DeepEquals, expected)
+}
+
+func (s *S) TestArchive_PassingWholeDir_WithTsuruIgnore(c *check.C) {
+	workingDir, err := os.Getwd()
+	c.Assert(err, check.IsNil)
+
+	defer func() { os.Chdir(workingDir) }()
+
+	err = os.Chdir(filepath.Join(workingDir, "./testdata/deploy2/"))
+	c.Assert(err, check.IsNil)
+
+	var b, stderr bytes.Buffer
+
+	err = Archiver(&b, false, []string{"."}, ArchiveOptions{IgnoreFiles: []string{".tsuruignore"}, Stderr: &stderr})
+	c.Assert(err, check.IsNil)
+
+	got := extractFiles(s.t, c, &b)
+	expected := []miniFile{
+		{Name: ".tsuruignore", Type: tar.TypeReg, Data: []byte("*.txt")},
+		{Name: "directory", Type: tar.TypeDir},
+		{Name: "directory/dir2", Type: tar.TypeDir},
+	}
+	c.Assert(got, check.DeepEquals, expected)
+
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Using pattern\(s\) from "\.tsuruignore" to include/exclude files\.\.\.(.*)`)
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)File "directory/dir2/file\.txt" matches with some pattern provided in the ignore file\.\.\. skipping it\.(.*)`)
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)File "directory/file\.txt" matches with some pattern provided in the ignore file\.\.\. skipping it\.(.*)`)
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)File "file1\.txt" matches with some pattern provided in the ignore file\.\.\. skipping it\.(.*)`)
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)File "file2\.txt" matches with some pattern provided in the ignore file\.\.\. skipping it\.(.*)`)
+}
+
+func (s *S) TestArchive_FilesOnly(c *check.C) {
+	var b bytes.Buffer
+	err := Archiver(&b, true, []string{"./testdata/deploy/directory/file.txt", "./testdata/deploy2/file1.txt"}, ArchiveOptions{})
+	c.Assert(err, check.IsNil)
+
+	got := extractFiles(s.t, c, &b)
+	expected := []miniFile{
+		{Name: "file.txt", Type: tar.TypeReg, Data: []byte("wat\n")},
+		{Name: "file1.txt", Type: tar.TypeReg, Data: []byte("something happened\n")},
+	}
+	c.Assert(got, check.DeepEquals, expected)
+}
+
+func (s *S) TestArchive_WithSymlink(c *check.C) {
+	workingDir, err := os.Getwd()
+	c.Assert(err, check.IsNil)
+
+	defer func() { os.Chdir(workingDir) }()
+
+	err = os.Chdir(filepath.Join(workingDir, "./testdata-symlink/"))
+	c.Assert(err, check.IsNil)
+
+	var b bytes.Buffer
+	err = Archiver(&b, false, []string{"."}, ArchiveOptions{})
+	c.Assert(err, check.IsNil)
+
+	got := extractFiles(s.t, c, &b)
+	expected := []miniFile{
+		{Name: "link", Linkname: "test", Type: tar.TypeSymlink},
+		{Name: "test", Type: tar.TypeDir},
+		{Name: "test/index.html", Type: tar.TypeReg, Data: []byte{}},
+	}
+	c.Assert(got, check.DeepEquals, expected)
+}
+
+func (s *S) TestArchive_UnsupportedFileType(c *check.C) {
+	workingDir, err := os.Getwd()
+	c.Assert(err, check.IsNil)
+
+	defer func() { os.Chdir(workingDir) }()
+
+	err = os.Chdir(c.MkDir())
+	c.Assert(err, check.IsNil)
+
+	l, err := net.Listen("unix", "./server.sock")
+	c.Assert(err, check.IsNil)
+	defer l.Close()
+
+	var stderr bytes.Buffer
+	err = Archiver(io.Discard, false, []string{"."}, ArchiveOptions{Stderr: &stderr})
+	c.Assert(err, check.ErrorMatches, "missing files to archive")
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)WARNING: Skipping file "server.sock" due to unsupported file type.(.*)`)
+}
+
+func (s *S) TestArchive_FilesOnly_MultipleDirs(c *check.C) {
+	var b, stderr bytes.Buffer
+	err := Archiver(&b, true, []string{"./testdata/deploy", "./testdata/deploy2"}, ArchiveOptions{Stderr: &stderr})
+	c.Assert(err, check.IsNil)
+
+	got := extractFiles(s.t, c, &b)
+	expected := []miniFile{
+		{Name: "file.txt", Type: tar.TypeReg, Data: []byte("wat\n")},
+		{Name: "file1.txt", Type: tar.TypeReg, Data: []byte("something happened\n")},
+		{Name: "file2.txt", Type: tar.TypeReg, Data: []byte("twice\n")},
+		{Name: ".tsuruignore", Type: tar.TypeReg, Data: []byte("*.txt")},
+	}
+	c.Assert(got, check.DeepEquals, expected)
+
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/directory/dir2/file.txt" as it already exists in the current directory.(.*)`)
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/directory/file.txt" as it already exists in the current directory.(.*)`)
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/file1.txt" as it already exists in the current directory.(.*)`)
+	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/file2.txt" as it already exists in the current directory.(.*)`)
+}
+
+func extractFiles(t *testing.T, c *check.C, r io.Reader) (m []miniFile) {
+	t.Helper()
+
+	gzr, err := gzip.NewReader(r)
+	c.Assert(err, check.IsNil)
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		h, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		c.Assert(err, check.IsNil)
+
+		var data []byte
+
+		if h.Typeflag == tar.TypeReg || h.Typeflag == tar.TypeRegA {
+			var b bytes.Buffer
+			written, err := io.CopyN(&b, tr, h.Size)
+			c.Assert(err, check.IsNil)
+			c.Assert(written, check.Equals, h.Size)
+			data = b.Bytes()
+		}
+
+		m = append(m, miniFile{
+			Name:     h.Name,
+			Linkname: h.Linkname,
+			Type:     h.Typeflag,
+			Data:     data,
+		})
+	}
+
+	return m
+}
+
+type miniFile struct {
+	Name     string
+	Linkname string
+	Type     byte
+	Data     []byte
+}

--- a/tsuru/client/archiver_test.go
+++ b/tsuru/client/archiver_test.go
@@ -19,21 +19,21 @@ import (
 )
 
 func (s *S) TestArchive_NoDestination(c *check.C) {
-	err := Archiver(nil, false, nil, ArchiveOptions{})
+	err := Archive(nil, false, nil, ArchiveOptions{})
 	c.Assert(err, check.ErrorMatches, "destination cannot be nil")
 }
 
 func (s *S) TestArchive_NoPaths(c *check.C) {
-	err := Archiver(io.Discard, false, nil, ArchiveOptions{})
+	err := Archive(io.Discard, false, nil, ArchiveOptions{})
 	c.Assert(err, check.ErrorMatches, "paths cannot be empty")
 
-	err = Archiver(io.Discard, false, []string{}, ArchiveOptions{})
+	err = Archive(io.Discard, false, []string{}, ArchiveOptions{})
 	c.Assert(err, check.ErrorMatches, "paths cannot be empty")
 }
 
 func (s *S) TestArchive_FileOutsideOfCurrentDir(c *check.C) {
 	var stderr bytes.Buffer
-	err := Archiver(io.Discard, false, []string{"../../../../var/www/html"}, ArchiveOptions{Stderr: &stderr})
+	err := Archive(io.Discard, false, []string{"../../../../var/www/html"}, ArchiveOptions{Stderr: &stderr})
 	c.Assert(err, check.ErrorMatches, "missing files to archive")
 	c.Assert(stderr.String(), check.Matches, `(?s).*WARNING: skipping file "\.\.\/\.\.\/\.\.\/\.\.\/var\/www\/html" since you cannot add files outside the current directory.*`)
 }
@@ -49,7 +49,7 @@ func (s *S) TestArchive_PassingWholeDir(c *check.C) {
 
 	var b bytes.Buffer
 
-	err = Archiver(&b, false, []string{"."}, ArchiveOptions{})
+	err = Archive(&b, false, []string{"."}, ArchiveOptions{})
 	c.Assert(err, check.IsNil)
 
 	got := extractFiles(s.t, c, &b)
@@ -73,7 +73,7 @@ func (s *S) TestArchive_PassingWholeDir_WithTsuruIgnore(c *check.C) {
 
 	var b, stderr bytes.Buffer
 
-	err = Archiver(&b, false, []string{"."}, ArchiveOptions{IgnoreFiles: []string{".tsuruignore"}, Stderr: &stderr})
+	err = Archive(&b, false, []string{"."}, ArchiveOptions{IgnoreFiles: []string{".tsuruignore"}, Stderr: &stderr})
 	c.Assert(err, check.IsNil)
 
 	got := extractFiles(s.t, c, &b)
@@ -93,7 +93,7 @@ func (s *S) TestArchive_PassingWholeDir_WithTsuruIgnore(c *check.C) {
 
 func (s *S) TestArchive_FilesOnly(c *check.C) {
 	var b bytes.Buffer
-	err := Archiver(&b, true, []string{"./testdata/deploy/directory/file.txt", "./testdata/deploy2/file1.txt"}, ArchiveOptions{})
+	err := Archive(&b, true, []string{"./testdata/deploy/directory/file.txt", "./testdata/deploy2/file1.txt"}, ArchiveOptions{})
 	c.Assert(err, check.IsNil)
 
 	got := extractFiles(s.t, c, &b)
@@ -114,7 +114,7 @@ func (s *S) TestArchive_WithSymlink(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	var b bytes.Buffer
-	err = Archiver(&b, false, []string{"."}, ArchiveOptions{})
+	err = Archive(&b, false, []string{"."}, ArchiveOptions{})
 	c.Assert(err, check.IsNil)
 
 	got := extractFiles(s.t, c, &b)
@@ -140,14 +140,14 @@ func (s *S) TestArchive_UnsupportedFileType(c *check.C) {
 	defer l.Close()
 
 	var stderr bytes.Buffer
-	err = Archiver(io.Discard, false, []string{"."}, ArchiveOptions{Stderr: &stderr})
+	err = Archive(io.Discard, false, []string{"."}, ArchiveOptions{Stderr: &stderr})
 	c.Assert(err, check.ErrorMatches, "missing files to archive")
 	c.Assert(stderr.String(), check.Matches, `(?s)(.*)WARNING: Skipping file "server.sock" due to unsupported file type.(.*)`)
 }
 
 func (s *S) TestArchive_FilesOnly_MultipleDirs(c *check.C) {
 	var b, stderr bytes.Buffer
-	err := Archiver(&b, true, []string{"./testdata/deploy", "./testdata/deploy2"}, ArchiveOptions{Stderr: &stderr})
+	err := Archive(&b, true, []string{"./testdata/deploy", "./testdata/deploy2"}, ArchiveOptions{Stderr: &stderr})
 	c.Assert(err, check.IsNil)
 
 	got := extractFiles(s.t, c, &b)

--- a/tsuru/client/archiver_unix_test.go
+++ b/tsuru/client/archiver_unix_test.go
@@ -10,13 +10,10 @@ package client
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
-	"errors"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
-	"testing"
 
 	check "gopkg.in/check.v1"
 )
@@ -166,48 +163,4 @@ func (s *S) TestArchive_FilesOnly_MultipleDirs(c *check.C) {
 	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/directory/file.txt" as it already exists in the current directory.(.*)`)
 	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/file1.txt" as it already exists in the current directory.(.*)`)
 	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/file2.txt" as it already exists in the current directory.(.*)`)
-}
-
-func extractFiles(t *testing.T, c *check.C, r io.Reader) (m []miniFile) {
-	t.Helper()
-
-	gzr, err := gzip.NewReader(r)
-	c.Assert(err, check.IsNil)
-
-	tr := tar.NewReader(gzr)
-
-	for {
-		h, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-
-		c.Assert(err, check.IsNil)
-
-		var data []byte
-
-		if h.Typeflag == tar.TypeReg || h.Typeflag == tar.TypeRegA {
-			var b bytes.Buffer
-			written, err := io.CopyN(&b, tr, h.Size)
-			c.Assert(err, check.IsNil)
-			c.Assert(written, check.Equals, h.Size)
-			data = b.Bytes()
-		}
-
-		m = append(m, miniFile{
-			Name:     h.Name,
-			Linkname: h.Linkname,
-			Type:     h.Typeflag,
-			Data:     data,
-		})
-	}
-
-	return m
-}
-
-type miniFile struct {
-	Name     string
-	Linkname string
-	Type     byte
-	Data     []byte
 }

--- a/tsuru/client/archiver_unix_test.go
+++ b/tsuru/client/archiver_unix_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
+// +build linux
+
 package client
 
 import (

--- a/tsuru/client/build.go
+++ b/tsuru/client/build.go
@@ -74,6 +74,14 @@ func (c *AppBuild) Run(context *cmd.Context, client *cmd.Client) error {
 	if len(context.Args) == 0 {
 		return errors.New("You should provide at least one file to build the image.\n")
 	}
+
+	debugWriter := io.Discard
+
+	debug := client != nil && client.Verbosity > 0 // e.g. --verbosity 2
+	if debug {
+		debugWriter = context.Stderr
+	}
+
 	appName, err := c.AppName()
 	if err != nil {
 		return err
@@ -105,7 +113,7 @@ func (c *AppBuild) Run(context *cmd.Context, client *cmd.Client) error {
 	respBody := prepareUploadStreams(context, buf)
 
 	var archive bytes.Buffer
-	err = Archive(&archive, c.filesOnly, context.Args, DefaultArchiveOptions(context.Stderr))
+	err = Archive(&archive, c.filesOnly, context.Args, DefaultArchiveOptions(debugWriter))
 	if err != nil {
 		return err
 	}

--- a/tsuru/client/build.go
+++ b/tsuru/client/build.go
@@ -188,7 +188,7 @@ func uploadFiles(context *cmd.Context, request *http.Request, buf *safe.Buffer, 
 				fmt.Fprintf(context.Stdout, " Processing%s", strings.Repeat(".", count))
 				count++
 			}
-			time.Sleep(2e9)
+			time.Sleep(2 * time.Second)
 		}
 	}()
 	return nil

--- a/tsuru/client/build.go
+++ b/tsuru/client/build.go
@@ -110,7 +110,7 @@ func (c *AppBuild) Run(context *cmd.Context, client *cmd.Client) error {
 		return err
 	}
 
-	if err = uploadFiles(context, c.filesOnly, request, buf, body, values, &archive); err != nil {
+	if err = uploadFiles(context, request, buf, body, values, &archive); err != nil {
 		return err
 	}
 	resp, err := client.Do(request)
@@ -131,7 +131,7 @@ func (c *AppBuild) Run(context *cmd.Context, client *cmd.Client) error {
 	return cmd.ErrAbortCommand
 }
 
-func uploadFiles(context *cmd.Context, filesOnly bool, request *http.Request, buf *safe.Buffer, body *safe.Buffer, values url.Values, archive io.Reader) error {
+func uploadFiles(context *cmd.Context, request *http.Request, buf *safe.Buffer, body *safe.Buffer, values url.Values, archive io.Reader) error {
 	if archive == nil {
 		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		_, err := body.WriteString(values.Encode())

--- a/tsuru/client/build.go
+++ b/tsuru/client/build.go
@@ -238,8 +238,9 @@ func guessingContainerFile(app, dir string) (string, error) {
 		path := filepath.Join(dir, name)
 
 		fi, err := os.Stat(path)
-		// check err != nil && err == "file not found"
-		//  continue
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
 
 		if err != nil {
 			return "", err
@@ -250,5 +251,5 @@ func guessingContainerFile(app, dir string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("container file not in %s", dir)
+	return "", errors.New("container file not found")
 }

--- a/tsuru/client/build.go
+++ b/tsuru/client/build.go
@@ -39,13 +39,24 @@ func (c *AppBuild) Flags() *gnuflag.FlagSet {
 }
 
 func (c *AppBuild) Info() *cmd.Info {
-	desc := `Builds a tsuru app image respecting .tsuruignore file. Some examples of calls are:
+	desc := `Build a container image following the app deploy's workflow - but do not change anything on the running application on Tsuru.
+You can deploy this container image to the app later.
 
-::
+Files specified in the ".tsuruignore" file are skipped - similar to ".gitignore".
 
-		$ tsuru app build -a myapp -t mytag .
-		$ tsuru app build -a myapp -t latest myfile.jar Procfile
-		$ tsuru app build -a myapp -t mytag -f directory/main.go directory/Procfile
+Examples:
+  To build using app's platform build process (just sending source code or configurations):
+    Uploading all files within the current directory
+      $ tsuru app build -a <APP> .
+
+    Uploading all files within a specific directory
+      $ tsuru app build -a <APP> mysite/
+
+    Uploading specific files
+      $ tsuru app build -a <APP> ./myfile.jar ./Procfile
+
+    Uploading specific files but ignoring their directory trees
+      $ tsuru app build -a <APP> --files-only ./my-code/main.go ./tsuru_stuff/Procfile
 `
 	return &cmd.Info{
 		Name:    "app-build",

--- a/tsuru/client/build_test.go
+++ b/tsuru/client/build_test.go
@@ -139,18 +139,22 @@ func (s *S) TestGuessingContainerFile(c *check.C) {
 			expectedError: "container file not found",
 		},
 		{
+			app:      "my-app",
 			files:    []string{"Containerfile"},
 			expected: func(root string) string { return filepath.Join(root, "Containerfile") },
 		},
 		{
+			app:      "my-app",
 			files:    []string{"Containerfile", "Dockerfile"},
 			expected: func(root string) string { return filepath.Join(root, "Dockerfile") },
 		},
 		{
+			app:      "my-app",
 			files:    []string{"Containerfile", "Dockerfile", "Containerfile.tsuru"},
 			expected: func(root string) string { return filepath.Join(root, "Containerfile.tsuru") },
 		},
 		{
+			app:      "my-app",
 			files:    []string{"Containerfile", "Dockerfile", "Containerfile.tsuru", "Dockerfile.tsuru"},
 			expected: func(root string) string { return filepath.Join(root, "Dockerfile.tsuru") },
 		},

--- a/tsuru/client/build_test.go
+++ b/tsuru/client/build_test.go
@@ -6,7 +6,7 @@ package client
 
 import (
 	"bytes"
-	"compress/gzip"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -24,10 +24,7 @@ func (s *S) TestBuildInfo(c *check.C) {
 func (s *S) TestBuildRun(c *check.C) {
 	calledTimes := 0
 	var buf bytes.Buffer
-	err := Archiver(&buf, false, []string{"testdata", ".."}, ArchiveOptions{
-		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
-		IgnoreFiles:      []string{".tsuruignore"},
-	})
+	err := Archive(&buf, false, []string{"testdata", ".."}, DefaultArchiveOptions(io.Discard))
 	c.Assert(err, check.IsNil)
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "\nOK\n", Status: http.StatusOK},
@@ -64,10 +61,7 @@ func (s *S) TestBuildRun(c *check.C) {
 
 func (s *S) TestBuildFail(c *check.C) {
 	var buf bytes.Buffer
-	err := Archiver(&buf, false, []string{"testdata", ".."}, ArchiveOptions{
-		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
-		IgnoreFiles:      []string{".tsuruignore"},
-	})
+	err := Archive(&buf, false, []string{"testdata", ".."}, DefaultArchiveOptions(io.Discard))
 	c.Assert(err, check.IsNil)
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "Failed", Status: http.StatusOK},

--- a/tsuru/client/deploy.go
+++ b/tsuru/client/deploy.go
@@ -185,7 +185,7 @@ Examples:
     Uploading specific files
       $ tsuru app deploy -a <APP> ./myfile.jar ./Procfile
 
-    Uploading specific files but ignoring their directory trees - do not respect .tsuruignore text file at all.
+    Uploading specific files but ignoring their directory trees
       $ tsuru app deploy -a <APP> --files-only ./my-code/main.go ./tsuru_stuff/Procfile
 
   To deploy using a container image:

--- a/tsuru/client/deploy.go
+++ b/tsuru/client/deploy.go
@@ -236,6 +236,13 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 		return errors.New("You can't deploy container image and container file at same time.\n")
 	}
 
+	debugWriter := io.Discard
+
+	debug := client != nil && client.Verbosity > 0 // e.g. --verbosity 2
+	if debug {
+		debugWriter = context.Stderr
+	}
+
 	appName, err := c.AppName()
 	if err != nil {
 		return err
@@ -283,7 +290,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 		fmt.Fprintln(context.Stdout, "Deploying with Dockerfile...")
 
 		var dockerfile string
-		dockerfile, archive, err = buildWithContainerFile(appName, c.dockerfile, c.filesOnly, context.Args, context.Stderr)
+		dockerfile, archive, err = buildWithContainerFile(appName, c.dockerfile, c.filesOnly, context.Args, debugWriter)
 		if err != nil {
 			return err
 		}
@@ -295,7 +302,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 		fmt.Fprintln(context.Stdout, "Deploying using app's platform...")
 
 		var buffer bytes.Buffer
-		err = Archive(&buffer, c.filesOnly, context.Args, DefaultArchiveOptions(context.Stderr))
+		err = Archive(&buffer, c.filesOnly, context.Args, DefaultArchiveOptions(debugWriter))
 		if err != nil {
 			return err
 		}

--- a/tsuru/client/deploy.go
+++ b/tsuru/client/deploy.go
@@ -303,7 +303,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 		archive = &buffer
 	}
 
-	if err = uploadFiles(context, c.filesOnly, request, buf, body, values, archive); err != nil {
+	if err = uploadFiles(context, request, buf, body, values, archive); err != nil {
 		return err
 	}
 

--- a/tsuru/client/deploy.go
+++ b/tsuru/client/deploy.go
@@ -6,7 +6,6 @@ package client
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -284,7 +283,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 		fmt.Fprintln(context.Stdout, "Deploying with Dockerfile...")
 
 		var dockerfile string
-		dockerfile, archive, err = buildWithContainerFile(appName, c.dockerfile, c.filesOnly, context.Args)
+		dockerfile, archive, err = buildWithContainerFile(appName, c.dockerfile, c.filesOnly, context.Args, context.Stderr)
 		if err != nil {
 			return err
 		}
@@ -296,10 +295,7 @@ func (c *AppDeploy) Run(context *cmd.Context, client *cmd.Client) error {
 		fmt.Fprintln(context.Stdout, "Deploying using app's platform...")
 
 		var buffer bytes.Buffer
-		err = Archiver(&buffer, c.filesOnly, context.Args, ArchiveOptions{
-			CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
-			IgnoreFiles:      []string{".tsuruignore"},
-		})
+		err = Archive(&buffer, c.filesOnly, context.Args, DefaultArchiveOptions(context.Stderr))
 		if err != nil {
 			return err
 		}

--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -5,18 +5,12 @@
 package client
 
 import (
-	"archive/tar"
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"path"
-	"path/filepath"
-	"runtime"
-	"sort"
 	"strings"
 	"time"
 
@@ -33,21 +27,18 @@ func (s *S) TestDeployInfo(c *check.C) {
 }
 
 func (s *S) TestDeployRun(c *check.C) {
-	calledTimes := 0
 	var buf bytes.Buffer
-	ctx := cmd.Context{Stderr: bytes.NewBufferString(""), Stdout: bytes.NewBufferString("")}
-	tm := newTarMaker(&ctx)
-	err := tm.targz(&buf, false, "testdata", "..")
+	err := Archiver(&buf, false, []string{"testdata", ".."}, ArchiveOptions{
+		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
+		IgnoreFiles:      []string{".tsuruignore"},
+	})
 	c.Assert(err, check.IsNil)
+
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},
 		CondFunc: func(req *http.Request) bool {
-			calledTimes++
 			if req.Body != nil {
 				defer req.Body.Close()
-			}
-			if calledTimes == 1 {
-				return req.Method == "GET" && strings.HasSuffix(req.URL.Path, "/apps/secret")
 			}
 			file, _, transErr := req.FormFile("file")
 			c.Assert(transErr, check.IsNil)
@@ -69,10 +60,8 @@ func (s *S) TestDeployRun(c *check.C) {
 	err = cmd.Flags().Parse(true, []string{"testdata", "..", "-a", "secret"})
 	c.Assert(err, check.IsNil)
 	context.Args = cmd.Flags().Args()
-
 	err = cmd.Run(&context, client)
 	c.Assert(err, check.IsNil)
-	c.Assert(calledTimes, check.Equals, 2)
 }
 
 type slowReader struct {
@@ -90,24 +79,15 @@ func (s *slowReader) Close() error {
 }
 
 func (s *S) TestDeployRunCancel(c *check.C) {
-	calledTimes := 0
 	var buf bytes.Buffer
-	ctx := cmd.Context{Stderr: bytes.NewBufferString(""), Stdout: bytes.NewBufferString("")}
-	tm := newTarMaker(&ctx)
-	err := tm.targz(&buf, false, "testdata", "..")
+	err := Archiver(&buf, false, []string{"testdata", ".."}, ArchiveOptions{
+		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
+		IgnoreFiles:      []string{".tsuruignore"},
+	})
 	c.Assert(err, check.IsNil)
 	deploy := make(chan struct{}, 1)
 	trans := cmdtest.MultiConditionalTransport{
 		ConditionalTransports: []cmdtest.ConditionalTransport{
-			{
-				Transport: cmdtest.Transport{Status: http.StatusOK},
-				CondFunc: func(req *http.Request) bool {
-					calledTimes++
-					c.Assert(req.Method, check.Equals, "GET")
-					c.Assert(req.URL.Path, check.Equals, "/1.0/apps/secret")
-					return true
-				},
-			},
 			{
 				Transport: &cmdtest.BodyTransport{
 					Status:  http.StatusOK,
@@ -116,7 +96,6 @@ func (s *S) TestDeployRunCancel(c *check.C) {
 				},
 				CondFunc: func(req *http.Request) bool {
 					deploy <- struct{}{}
-					calledTimes++
 					if req.Body != nil {
 						defer req.Body.Close()
 					}
@@ -133,7 +112,6 @@ func (s *S) TestDeployRunCancel(c *check.C) {
 			{
 				Transport: cmdtest.Transport{Status: http.StatusOK},
 				CondFunc: func(req *http.Request) bool {
-					calledTimes++
 					c.Assert(req.Method, check.Equals, "POST")
 					c.Assert(req.URL.Path, check.Equals, "/1.1/events/5aec54d93195b20001194951/cancel")
 					return true
@@ -162,25 +140,20 @@ func (s *S) TestDeployRunCancel(c *check.C) {
 	<-deploy
 	err = cmd.Cancel(context, client)
 	c.Assert(err, check.IsNil)
-	c.Assert(calledTimes, check.Equals, 3)
 }
 
 func (s *S) TestDeployImage(c *check.C) {
-	calledTimes := 0
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},
 		CondFunc: func(req *http.Request) bool {
-			calledTimes++
 			if req.Body != nil {
 				defer req.Body.Close()
 			}
-			if calledTimes == 1 {
-				return req.Method == "GET" && strings.HasSuffix(req.URL.Path, "/apps/secret")
-			}
-			image := req.FormValue("image")
-			c.Assert(image, check.Equals, "registr.com/image-to-deploy")
-			c.Assert(req.Header.Get("Content-Type"), check.Equals, "application/x-www-form-urlencoded")
+			c.Assert(req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
+			c.Assert(req.FormValue("image"), check.Equals, "registr.com/image-to-deploy")
 			c.Assert(req.FormValue("origin"), check.Equals, "image")
+			_, _, err := req.FormFile("file")
+			c.Assert(err, check.Equals, http.ErrMissingFile)
 			return req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/apps/secret/deploy")
 		},
 	}
@@ -196,25 +169,20 @@ func (s *S) TestDeployImage(c *check.C) {
 	context.Args = cmd.Flags().Args()
 	err = cmd.Run(&context, client)
 	c.Assert(err, check.IsNil)
-	c.Assert(calledTimes, check.Equals, 2)
 }
 
 func (s *S) TestDeployRunWithMessage(c *check.C) {
-	calledTimes := 0
 	var buf bytes.Buffer
-	ctx := cmd.Context{Stderr: bytes.NewBufferString(""), Stdout: bytes.NewBufferString("")}
-	tm := newTarMaker(&ctx)
-	err := tm.targz(&buf, false, "testdata", "..")
+	err := Archiver(&buf, false, []string{"testdata", ".."}, ArchiveOptions{
+		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
+		IgnoreFiles:      []string{".tsuruignore"},
+	})
 	c.Assert(err, check.IsNil)
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},
 		CondFunc: func(req *http.Request) bool {
-			calledTimes++
 			if req.Body != nil {
 				defer req.Body.Close()
-			}
-			if calledTimes == 1 {
-				return req.Method == "GET" && strings.HasSuffix(req.URL.Path, "/apps/secret")
 			}
 			file, _, transErr := req.FormFile("file")
 			c.Assert(transErr, check.IsNil)
@@ -239,16 +207,13 @@ func (s *S) TestDeployRunWithMessage(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = cmd.Run(&context, client)
 	c.Assert(err, check.IsNil)
-	c.Assert(calledTimes, check.Equals, 2)
 }
 
 func (s *S) TestDeployAuthNotOK(c *check.C) {
-	calledTimes := 0
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "Forbidden", Status: http.StatusForbidden},
 		CondFunc: func(req *http.Request) bool {
-			calledTimes++
-			return req.Method == "GET" && strings.HasSuffix(req.URL.Path, "/apps/secret")
+			return req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/apps/secret/deploy")
 		},
 	}
 	client := cmd.NewClient(&http.Client{Transport: &trans}, nil, manager)
@@ -264,7 +229,6 @@ func (s *S) TestDeployAuthNotOK(c *check.C) {
 	context.Args = command.Flags().Args()
 	err = command.Run(&context, client)
 	c.Assert(err, check.ErrorMatches, "Forbidden")
-	c.Assert(calledTimes, check.Equals, 1)
 }
 
 func (s *S) TestDeployRunNotOK(c *check.C) {
@@ -302,90 +266,45 @@ func (s *S) TestDeployRunFileNotFound(c *check.C) {
 }
 
 func (s *S) TestDeployRunWithoutArgsAndImage(c *check.C) {
-	var stdout, stderr bytes.Buffer
-	ctx := cmd.Context{
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Args:   []string{"-a", "secret"},
-	}
-	trans := cmdtest.Transport{Message: "OK\n", Status: http.StatusOK}
-	client := cmd.NewClient(&http.Client{Transport: &trans}, nil, manager)
 	command := AppDeploy{}
-	err := command.Flags().Parse(true, ctx.Args)
+	err := command.Flags().Parse(true, []string{"-a", "secret"})
 	c.Assert(err, check.IsNil)
-	ctx.Args = command.Flags().Args()
-	err = command.Run(&ctx, client)
+	ctx := &cmd.Context{Stdout: io.Discard, Stderr: io.Discard, Args: command.Flags().Args()}
+	client := cmd.NewClient(&http.Client{Transport: &cmdtest.Transport{Status: http.StatusInternalServerError}}, nil, manager)
+	err = command.Run(ctx, client)
 	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, "You should provide at least one file or a docker image to deploy.\n")
+	c.Assert(err.Error(), check.Equals, "You should provide at least one file, Docker image name or Dockerfile to deploy.\n")
 }
 
 func (s *S) TestDeployRunWithArgsAndImage(c *check.C) {
-	var stdout, stderr bytes.Buffer
-	ctx := cmd.Context{
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Args:   []string{"testdata", "..", "-a", "secret"},
-	}
-	trans := cmdtest.Transport{Message: "OK\n", Status: http.StatusOK}
-	client := cmd.NewClient(&http.Client{Transport: &trans}, nil, manager)
 	command := AppDeploy{}
-	command.Flags().Parse(true, []string{"-i", "registr.com/image-to-deploy"})
-	err := command.Run(&ctx, client)
-	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, "You can't deploy files and docker image at the same time.\n")
+	err := command.Flags().Parse(true, []string{"-i", "registr.com/image-to-deploy", "./path/to/dir"})
+	c.Assert(err, check.IsNil)
+	ctx := &cmd.Context{Stdout: io.Discard, Stderr: io.Discard, Args: command.Flags().Args()}
+	client := cmd.NewClient(&http.Client{Transport: &cmdtest.Transport{Status: http.StatusInternalServerError}}, nil, manager)
+	err = command.Run(ctx, client)
+	c.Assert(err, check.ErrorMatches, "You can't deploy files and docker image at the same time.\n")
 }
 
 func (s *S) TestDeployRunRequestFailure(c *check.C) {
 	trans := cmdtest.Transport{Message: "app not found\n", Status: http.StatusNotFound}
 	client := cmd.NewClient(&http.Client{Transport: &trans}, nil, manager)
-	var stdout, stderr bytes.Buffer
-	context := cmd.Context{
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Args:   []string{"testdata", "..", "-a", "secret"},
-	}
 	command := AppDeploy{}
-	err := command.Flags().Parse(true, context.Args)
+	err := command.Flags().Parse(true, []string{"testdata", "..", "-a", "secret"})
 	c.Assert(err, check.IsNil)
-	context.Args = command.Flags().Args()
-	err = command.Run(&context, client)
-	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, "app not found\n")
+	ctx := &cmd.Context{Stdout: io.Discard, Stderr: io.Discard, Args: command.Flags().Args()}
+	err = command.Run(ctx, client)
+	c.Assert(err, check.ErrorMatches, "app not found\n")
 }
 
-func (s *S) TestTargzSymlink(c *check.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("no symlink support on windows")
-	}
-	var buf, outBuf bytes.Buffer
-	ctx := cmd.Context{Stderr: &buf, Stdout: &outBuf}
-	var gzipBuf, tarBuf bytes.Buffer
-	tm := newTarMaker(&ctx)
-	err := tm.targz(&gzipBuf, false, "testdata-symlink", "..")
+func (s *S) TestDeploy_Run_DockerfileAndDockerImage(c *check.C) {
+	command := AppDeploy{}
+	err := command.Flags().Parse(true, []string{"-i", "registry.example.com/my-team/my-app:v42", "--dockerfile", "."})
 	c.Assert(err, check.IsNil)
-	gzipReader, err := gzip.NewReader(&gzipBuf)
-	c.Assert(err, check.IsNil)
-	_, err = io.Copy(&tarBuf, gzipReader)
-	c.Assert(err, check.IsNil)
-	tarReader := tar.NewReader(&tarBuf)
-	var headers [][]string
-	for header, err := tarReader.Next(); err == nil; header, err = tarReader.Next() {
-		if header.Linkname != "" {
-			headers = append(headers, []string{header.Name, header.Linkname})
-		}
-	}
-	expected := [][]string{{"testdata-symlink/link", "test"}}
-	c.Assert(headers, check.DeepEquals, expected)
-}
-
-func (s *S) TestTargzFailure(c *check.C) {
-	var stderr, stdout bytes.Buffer
-	ctx := cmd.Context{Stderr: &stderr, Stdout: &stdout}
-	var buf bytes.Buffer
-	tm := newTarMaker(&ctx)
-	err := tm.targz(&buf, false, "/tmp/something/that/definitely/doesn't/exist/right", "testdata")
-	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Matches, ".*(no such file or directory|cannot find the path specified).*")
+	ctx := &cmd.Context{Stdout: io.Discard, Stderr: io.Discard, Args: command.Flags().Args()}
+	client := cmd.NewClient(&http.Client{Transport: &cmdtest.Transport{Status: http.StatusInternalServerError}}, nil, manager)
+	err = command.Run(ctx, client)
+	c.Assert(err, check.ErrorMatches, "You can't deploy container image and container file at same time.\n")
 }
 
 func (s *S) TestDeployListInfo(c *check.C) {
@@ -618,187 +537,4 @@ func (s *S) TestAppDeployRebuild(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(called, check.Equals, true)
 	c.Assert(stdout.String(), check.Equals, expectedOut)
-}
-
-func (s *S) TestDeployRunTarGeneration(c *check.C) {
-	var foundFiles []string
-	trans := cmdtest.ConditionalTransport{
-		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},
-		CondFunc: func(req *http.Request) bool {
-			if req.Method == "GET" {
-				return true
-			}
-			defer req.Body.Close()
-			file, _, transErr := req.FormFile("file")
-			c.Assert(transErr, check.IsNil)
-			gzReader, transErr := gzip.NewReader(file)
-			c.Assert(transErr, check.IsNil)
-			tarReader := tar.NewReader(gzReader)
-			foundFiles = nil
-			for {
-				header, transErr := tarReader.Next()
-				if transErr == io.EOF {
-					break
-				}
-				c.Assert(transErr, check.IsNil)
-				foundFiles = append(foundFiles, header.Name)
-			}
-			return true
-		},
-	}
-	client := cmd.NewClient(&http.Client{Transport: &trans}, nil, manager)
-	tests := []struct {
-		files          []string
-		ignored        []string
-		deployArgs     []string
-		flags          []string
-		expected       []string
-		expectedStderr string
-		absPath        bool
-	}{
-		{
-			files:      []string{"f1", "f2", "d1/f3", "d1/d2/f4"},
-			deployArgs: []string{"."},
-			expected:   []string{"f1", "f2", "d1", "d1/f3", "d1/d2", "d1/d2/f4"},
-			flags:      []string{"-a", "secret"},
-		},
-		{
-			files:      []string{"testdata/deploy/file1.txt", "testdata/deploy2/file2.txt"},
-			deployArgs: []string{"testdata/deploy/file1.txt", "testdata/deploy2/file2.txt"},
-			expected:   []string{"testdata/deploy/file1.txt", "testdata/deploy2/file2.txt"},
-			flags:      []string{"-a", "secret"},
-		},
-		{
-			files:      []string{"testdata/deploy/file1.txt", "testdata/deploy2/file2.txt"},
-			deployArgs: []string{"testdata/deploy/file1.txt", "testdata/deploy2/file2.txt"},
-			flags:      []string{"-a", "secret", "-f"},
-			expected:   []string{"file1.txt", "file2.txt"},
-		},
-		{
-			files:      []string{"testdata/deploy/file1.txt", "testdata/deploy/file2.txt", "testdata/deploy2/file3.txt", "testdata/deploy2/directory/file4.txt"},
-			deployArgs: []string{"testdata/deploy", "testdata/deploy2"},
-			flags:      []string{"-a", "secret"},
-			expected:   []string{"testdata/deploy", "testdata/deploy2", "testdata/deploy/file1.txt", "testdata/deploy/file2.txt", "testdata/deploy2/file3.txt", "testdata/deploy2/directory", "testdata/deploy2/directory/file4.txt"},
-		},
-		{
-			files:      []string{"testdata/deploy/file1.txt", "testdata/deploy/file2.txt", "testdata/deploy2/file3.txt", "testdata/deploy2/directory/file4.txt"},
-			deployArgs: []string{"testdata/deploy", "testdata/deploy2"},
-			flags:      []string{"-a", "secret", "-f"},
-			expected:   []string{"file1.txt", "file2.txt", "file3.txt", "directory", "directory/file4.txt"},
-		},
-		{
-			files:          []string{"testdata/deploy/file1.txt", "testdata/deploy/file2.txt", "testdata/deploy/directory/file.txt"},
-			deployArgs:     []string{"testdata/deploy", ".."},
-			flags:          []string{"-a", "secret"},
-			expected:       []string{"testdata/deploy", "testdata/deploy/file1.txt", "testdata/deploy/file2.txt", "testdata/deploy/directory", "testdata/deploy/directory/file.txt"},
-			expectedStderr: `Warning: skipping "\.\."`,
-		},
-		{
-			files:      []string{"testdata/deploy/file1.txt", "testdata/deploy/file2.txt", "testdata/deploy/directory/file.txt"},
-			deployArgs: []string{"testdata/deploy"},
-			flags:      []string{"-a", "secret"},
-			expected:   []string{"file1.txt", "file2.txt", "directory", "directory/file.txt"},
-		},
-		{
-			files:      []string{"testdata/deploy2/file1.txt", "testdata/deploy2/file2.txt", "testdata/deploy2/directory/file.txt", "testdata/deploy2/directory/dir2/file.txt"},
-			ignored:    []string{"*.txt"},
-			flags:      []string{"-a", "secret"},
-			deployArgs: []string{"testdata/deploy2"},
-			expected:   []string{"directory", "directory/dir2"},
-		},
-		{
-			files:      []string{"testdata/deploy/file1.txt", "testdata/deploy/file2.txt", "testdata/deploy2/file3.txt", "testdata/deploy2/directory/file4.txt"},
-			deployArgs: []string{"testdata/deploy", "testdata/deploy2"},
-			ignored:    []string{"*.txt"},
-			flags:      []string{"-a", "secret"},
-			expected:   []string{"testdata/deploy", "testdata/deploy2", "testdata/deploy2/directory"},
-		},
-		{
-			files:      []string{"testdata/deploy/file1.txt", "testdata/deploy/file2.txt", "testdata/deploy2/file3.txt", "testdata/deploy2/directory/file4.txt"},
-			deployArgs: []string{"testdata/deploy", "testdata/deploy2"},
-			ignored:    []string{"*.txt"},
-			flags:      []string{"-a", "secret", "-f"},
-			expected:   []string{"directory"},
-		},
-		{
-			files:      []string{"testdata/deploy2/file1.txt", "testdata/deploy2/file2.txt", "testdata/deploy2/directory/file.txt", "testdata/deploy2/directory/dir2/file.txt"},
-			ignored:    []string{"*.txt"},
-			deployArgs: []string{"testdata/deploy2"},
-			flags:      []string{"-a", "secret"},
-			expected:   []string{"directory", "directory/dir2"},
-			absPath:    true,
-		},
-		{
-			files:      []string{"file1.txt", "file2.txt", "directory/file.txt", "directory/dir2/file.txt"},
-			ignored:    []string{"*.txt"},
-			deployArgs: []string{"."},
-			flags:      []string{"-a", "secret"},
-			expected:   []string{".tsuruignore", "directory", "directory/dir2"},
-		},
-		{
-			files:      []string{"testdata/deploy2/file1.txt", "testdata/deploy2/file2.txt", "testdata/deploy2/directory/file.txt", "testdata/deploy2/directory/dir2/file.txt"},
-			ignored:    []string{"directory"},
-			deployArgs: []string{"testdata/deploy2"},
-			flags:      []string{"-a", "secret"},
-			expected:   []string{"file1.txt", "file2.txt"},
-		},
-		{
-			files:      []string{"testdata/deploy2/file1.txt", "testdata/deploy2/file2.txt", "testdata/deploy2/directory/file.txt", "testdata/deploy2/directory/dir2/file.txt"},
-			ignored:    []string{"*/dir2"},
-			deployArgs: []string{"testdata/deploy2"},
-			flags:      []string{"-a", "secret"},
-			expected:   []string{"directory", "directory/file.txt", "file1.txt", "file2.txt"},
-		},
-		{
-			files:      []string{"testdata/deploy2/file1.txt", "testdata/deploy2/file2.txt", "testdata/deploy2/directory/file.txt", "testdata/deploy2/directory/dir2/file.txt"},
-			ignored:    []string{"directory/dir2/*"},
-			deployArgs: []string{"testdata/deploy2"},
-			flags:      []string{"-a", "secret"},
-			expected:   []string{"directory", "directory/dir2", "directory/file.txt", "file1.txt", "file2.txt"},
-		},
-	}
-	origDir, err := os.Getwd()
-	c.Assert(err, check.IsNil)
-	defer os.Chdir(origDir)
-	for i, tt := range tests {
-		comment := check.Commentf("test %d", i)
-
-		tmpDir, err := ioutil.TempDir("", "integration")
-		c.Assert(err, check.IsNil)
-		defer os.RemoveAll(tmpDir)
-		err = os.Chdir(tmpDir)
-		c.Assert(err, check.IsNil)
-		for _, f := range tt.files {
-			err = os.MkdirAll(path.Dir(f), 0700)
-			c.Assert(err, check.IsNil)
-			err = ioutil.WriteFile(f, []byte{}, 0600)
-			c.Assert(err, check.IsNil)
-		}
-		if len(tt.ignored) > 0 {
-			err = ioutil.WriteFile(".tsuruignore", []byte(strings.Join(tt.ignored, "\n")), 0600)
-			c.Assert(err, check.IsNil)
-		}
-
-		var stdout, stderr bytes.Buffer
-		if tt.absPath {
-			for i, f := range tt.deployArgs {
-				tt.deployArgs[i], err = filepath.Abs(f)
-				c.Assert(err, check.IsNil)
-			}
-		}
-		context := cmd.Context{
-			Stdout: &stdout,
-			Stderr: &stderr,
-			Args:   tt.deployArgs,
-		}
-		cmd := AppDeploy{}
-		err = cmd.Flags().Parse(true, append([]string{"-a", "secret"}, tt.flags...))
-		c.Assert(err, check.IsNil)
-		err = cmd.Run(&context, client)
-		c.Assert(err, check.IsNil, comment)
-		sort.Strings(foundFiles)
-		sort.Strings(tt.expected)
-		c.Assert(foundFiles, check.DeepEquals, tt.expected, comment)
-		c.Assert(stderr.String(), check.Matches, tt.expectedStderr, comment)
-	}
 }

--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -6,7 +6,6 @@ package client
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -28,10 +27,7 @@ func (s *S) TestDeployInfo(c *check.C) {
 
 func (s *S) TestDeployRun(c *check.C) {
 	var buf bytes.Buffer
-	err := Archiver(&buf, false, []string{"testdata", ".."}, ArchiveOptions{
-		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
-		IgnoreFiles:      []string{".tsuruignore"},
-	})
+	err := Archive(&buf, false, []string{"testdata", ".."}, DefaultArchiveOptions(io.Discard))
 	c.Assert(err, check.IsNil)
 
 	trans := cmdtest.ConditionalTransport{
@@ -80,10 +76,7 @@ func (s *slowReader) Close() error {
 
 func (s *S) TestDeployRunCancel(c *check.C) {
 	var buf bytes.Buffer
-	err := Archiver(&buf, false, []string{"testdata", ".."}, ArchiveOptions{
-		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
-		IgnoreFiles:      []string{".tsuruignore"},
-	})
+	err := Archive(&buf, false, []string{"testdata", ".."}, DefaultArchiveOptions(io.Discard))
 	c.Assert(err, check.IsNil)
 	deploy := make(chan struct{}, 1)
 	trans := cmdtest.MultiConditionalTransport{
@@ -173,10 +166,7 @@ func (s *S) TestDeployImage(c *check.C) {
 
 func (s *S) TestDeployRunWithMessage(c *check.C) {
 	var buf bytes.Buffer
-	err := Archiver(&buf, false, []string{"testdata", ".."}, ArchiveOptions{
-		CompressionLevel: func(lvl int) *int { return &lvl }(gzip.BestCompression),
-		IgnoreFiles:      []string{".tsuruignore"},
-	})
+	err := Archive(&buf, false, []string{"testdata", ".."}, DefaultArchiveOptions(io.Discard))
 	c.Assert(err, check.IsNil)
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: "deploy worked\nOK\n", Status: http.StatusOK},

--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -144,11 +144,9 @@ func (s *S) TestDeployImage(c *check.C) {
 			if req.Body != nil {
 				defer req.Body.Close()
 			}
-			c.Assert(req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
+			c.Assert(req.Header.Get("Content-Type"), check.Matches, "application/x-www-form-urlencoded")
 			c.Assert(req.FormValue("image"), check.Equals, "registr.com/image-to-deploy")
 			c.Assert(req.FormValue("origin"), check.Equals, "image")
-			_, _, err := req.FormFile("file")
-			c.Assert(err, check.Equals, http.ErrMissingFile)
 			return req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/apps/secret/deploy")
 		},
 	}

--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -315,8 +315,8 @@ func (s *S) TestDeploy_Run_UsingDockerfile(c *check.C) {
 			c.Assert(req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
 			c.Assert(req.FormValue("dockerfile"), check.Equals, "FROM busybox:latest\n\nCOPY ./app.sh /usr/local/bin/\n")
 
-			file, _, err := req.FormFile("file")
-			c.Assert(err, check.IsNil)
+			file, _, nerr := req.FormFile("file")
+			c.Assert(nerr, check.IsNil)
 			defer file.Close()
 			files := extractFiles(s.t, c, file)
 			c.Assert(files, check.DeepEquals, []miniFile{

--- a/tsuru/client/suite_test.go
+++ b/tsuru/client/suite_test.go
@@ -18,6 +18,7 @@ import (
 
 type S struct {
 	defaultLocation time.Location
+	t               *testing.T
 }
 
 func (s *S) SetUpSuite(c *check.C) {
@@ -47,7 +48,11 @@ func (s *S) TearDownTest(c *check.C) {
 	formatter.LocalTZ = &s.defaultLocation
 }
 
-var _ = check.Suite(&S{})
+var suite = &S{}
+var _ = check.Suite(suite)
 var manager *cmd.Manager
 
-func Test(t *testing.T) { check.TestingT(t) }
+func Test(t *testing.T) {
+	suite.t = t
+	check.TestingT(t)
+}

--- a/tsuru/client/testdata/deploy4/Dockerfile
+++ b/tsuru/client/testdata/deploy4/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox:latest
+
+COPY ./app.sh /usr/local/bin/

--- a/tsuru/client/testdata/deploy4/app.sh
+++ b/tsuru/client/testdata/deploy4/app.sh
@@ -1,0 +1,1 @@
+echo "Starting my application :P"


### PR DESCRIPTION
This PR implements the changes required to support deploy with Dockerfile (and files). 

Significant changes:
* Adds a new parameter `--dockerfile` on `tsuru app-deploy`;
* Changes the default compression level to best (9) - more CPU usage during the deploy/build;
* Rewrites the command description of `tsuru app-deploy` and `tsuru app-build`;
* Shows more info messages while compressing files to `archive.tar.gz`;