### PR TITLE
shell agnostic Autocomplete 

### DIFF
--- a/completions/README.md
+++ b/completions/README.md
@@ -1,0 +1,44 @@
+# Shell Agnostic Autocomplete
+
+## Install on bash
+
+Choose one of this options:
+
+- place the file inside `/etc/bash_completion.d/`
+  ```
+  cp completions/tsuru.bash /etc/bash_completion.d/tsuru.sh
+  ```
+
+  or
+
+- place the file in your location of choice (e.g. `~/.tsuru-completion.sh`)
+  and source that file from .bashrc
+  ```
+  cp completions/tsuru.bash ~/.tsuru-completion.sh
+  echo '. ~/.tsuru-completion.sh' >> ~/.bashrc
+  ```
+
+then, reopen your shell.
+
+## Install on zsh
+
+If you use oh-my-zsh, place the file at `~/.oh-my-zsh/completions/_tsuru`:
+```
+cp completions/tsuru.zsh ~/.oh-my-zsh/completions/_tsuru
+```
+
+If you use plain zsh, place the file at `~/.config/zsh/completions/_tsuru`:
+```
+cp completions/tsuru.zsh ~/.config/zsh/completions/_tsuru
+```
+
+then, reopen your shell.
+
+## Install on fish
+
+Place the file at `~/.config/fish/completions/tsuru.fish`:
+```
+cp completions/tsuru.fish ~/.config/fish/completions/tsuru.fish
+```
+
+then, reopen your shell.

--- a/completions/README.md
+++ b/completions/README.md
@@ -11,26 +11,27 @@ Choose one of this options:
 
   or
 
-- place the file in your location of choice (e.g. `~/.tsuru-completion.sh`)
-  and source that file from .bashrc
+- place the file in your location of choice and source that file from `.bashrc`
   ```
   cp completions/tsuru.bash ~/.tsuru-completion.sh
-  echo '. ~/.tsuru-completion.sh' >> ~/.bashrc
+  grep -qxF '. ~/.tsuru-completion.sh' ~/.bashrc || echo "\n. ~/.tsuru-completion.sh" >> ~/.bashrc
   ```
 
 then, reopen your shell.
 
 ## Install on zsh
 
-If you use oh-my-zsh, place the file at `~/.oh-my-zsh/completions/_tsuru`:
-```
-cp completions/tsuru.zsh ~/.oh-my-zsh/completions/_tsuru
-```
+Choose one of this options:
 
-If you use plain zsh, place the file at `~/.config/zsh/completions/_tsuru`:
-```
-cp completions/tsuru.zsh ~/.config/zsh/completions/_tsuru
-```
+- place the file inside your framework (eg: oh-my-zsh) completions folder
+
+  or
+
+- place the file in your location of choice and source that file from `.zshrc`
+  ```
+  cp completions/tsuru.zsh ~/.tsuru-completion.zsh
+  grep -qxF '. ~/.tsuru-completion.zsh' ~/.zshrc || echo "\n. ~/.tsuru-completion.zsh" >> ~/.zshrc
+  ```
 
 then, reopen your shell.
 

--- a/completions/tsuru.bash
+++ b/completions/tsuru.bash
@@ -1,0 +1,7 @@
+_tsuru() {
+  curr_line="${COMP_LINE:0:$COMP_POINT}"
+  suggestions=$( AUTOCOMPLETE_CURRENT_LINE="${curr_line}" "${TSURU_PATH:-tsuru}" )
+  COMPREPLY=( $(compgen -W "${suggestions}") )
+}
+
+complete -F _tsuru tsuru

--- a/completions/tsuru.fish
+++ b/completions/tsuru.fish
@@ -1,0 +1,9 @@
+function __fish_tsuru
+  complete -c tsuru --erase
+  complete -fc tsuru -a "(__fish_tsuru)"
+  set -q TSURU_PATH; or set -x TSURU_PATH tsuru
+  set -x AUTOCOMPLETE_CURRENT_LINE $(commandline -cp)
+  printf "$($TSURU_PATH)"
+end
+
+complete -fc tsuru -a "(__fish_tsuru)"

--- a/completions/tsuru.zsh
+++ b/completions/tsuru.zsh
@@ -1,0 +1,4 @@
+_tsuru(){
+  compadd -- $(AUTOCOMPLETE_CURRENT_LINE="$LBUFFER" "${TSURU_PATH:-tsuru}")
+}
+compdef _tsuru tsuru

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/exoscale/egoscale v0.9.31 // indirect
 	github.com/fsouza/go-dockerclient v1.7.4
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/iancoleman/orderedmap v0.2.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -504,6 +504,8 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/tsuru/autocomplete.go
+++ b/tsuru/autocomplete.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/tsuru/tsuru/cmd"
+)
+
+func getAllTopics(m *cmd.Manager) []string {
+	var result []string
+	for key := range m.Commands {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func getSuggestions(m *cmd.Manager, compLine []string) []string {
+	compLine = compLine[1:] // remove first "tsuru"
+	spacedCompLine := strings.Join(compLine, " ")
+
+	counter := map[string]int{}
+	for cmdName, comm := range m.Commands {
+		if _, isDeprecated := comm.(*cmd.DeprecatedCommand); isDeprecated {
+			continue
+		}
+		spacedCommand := strings.ReplaceAll(cmdName, "-", " ")
+		splitCommand := strings.Split(cmdName, "-")
+
+		if strings.HasPrefix(spacedCommand, spacedCompLine) &&
+			len(splitCommand) >= len(compLine) {
+			counter[splitCommand[len(compLine)-1]] += 1
+		}
+	}
+
+	var result []string
+	for topic := range counter {
+		result = append(result, topic)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func handleAutocomplete() bool {
+	compLine := os.Getenv("COMP_LINE")
+	if compLine == "" {
+		return false
+	}
+	compLineSlice := strings.Split(compLine, " ")
+
+	m := buildManager("tsuru")
+	fmt.Println(strings.Join(getSuggestions(m, compLineSlice), "\n"))
+	return true
+}

--- a/tsuru/autocomplete.go
+++ b/tsuru/autocomplete.go
@@ -10,8 +10,12 @@ import (
 	"github.com/tsuru/tsuru/cmd"
 )
 
-func getSuggestions(m *cmd.Manager, currLine []string) []string {
-	currLine = currLine[1:] // remove first "tsuru"
+func getSuggestions(m *cmd.Manager, fullCurrLine []string) []string {
+	if len(fullCurrLine) <= 1 {
+		return []string{} // first argument is expected to be the binary name
+	}
+
+	currLine := fullCurrLine[1:] // remove first "tsuru"
 	spacedcurrLine := strings.Join(currLine, " ")
 
 	counter := map[string]int{}
@@ -36,19 +40,19 @@ func getSuggestions(m *cmd.Manager, currLine []string) []string {
 	return result
 }
 
+// examples for AUTOCOMPLETE_CURRENT_LINE: "tsuru ", "tsuru app s"
 func handleAutocomplete() bool {
 	currLine := os.Getenv("AUTOCOMPLETE_CURRENT_LINE")
 	if currLine == "" {
 		return false
 	}
 	currLineSlice, err := shlex.Split(currLine)
-	if err != nil {
-		// incomplete quote, ignore autocomplete
+	if err != nil || len(currLineSlice) == 0 {
 		return true
 	}
 
 	if currLine[len(currLine)-1] == ' ' {
-		currLineSlice = append(currLineSlice, "") // shlex trims.Split() the last empty space, so we need to add it back
+		currLineSlice = append(currLineSlice, "") // shlex.Split() trims the last empty space, so we need to add it back
 	}
 
 	m := buildManager("tsuru")

--- a/tsuru/autocomplete.go
+++ b/tsuru/autocomplete.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/shlex"
 	"github.com/tsuru/tsuru/cmd"
 )
 
@@ -49,7 +50,15 @@ func handleAutocomplete() bool {
 	if currLine == "" {
 		return false
 	}
-	currLineSlice := strings.Split(currLine, " ") // TODO: handle quotes
+	currLineSlice, err := shlex.Split(currLine)
+	if err != nil {
+		// incomplete quote, ignore autocomplete
+		return true
+	}
+
+	if currLine[len(currLine)-1] == ' ' {
+		currLineSlice = append(currLineSlice, "") // shlex trims.Split() the last empty space, so we need to add it back
+	}
 
 	m := buildManager("tsuru")
 	fmt.Println(strings.Join(getSuggestions(m, currLineSlice), "\n"))

--- a/tsuru/autocomplete.go
+++ b/tsuru/autocomplete.go
@@ -10,15 +10,6 @@ import (
 	"github.com/tsuru/tsuru/cmd"
 )
 
-func getAllTopics(m *cmd.Manager) []string {
-	var result []string
-	for key := range m.Commands {
-		result = append(result, key)
-	}
-	sort.Strings(result)
-	return result
-}
-
 func getSuggestions(m *cmd.Manager, currLine []string) []string {
 	currLine = currLine[1:] // remove first "tsuru"
 	spacedcurrLine := strings.Join(currLine, " ")

--- a/tsuru/autocomplete.go
+++ b/tsuru/autocomplete.go
@@ -18,9 +18,9 @@ func getAllTopics(m *cmd.Manager) []string {
 	return result
 }
 
-func getSuggestions(m *cmd.Manager, compLine []string) []string {
-	compLine = compLine[1:] // remove first "tsuru"
-	spacedCompLine := strings.Join(compLine, " ")
+func getSuggestions(m *cmd.Manager, currLine []string) []string {
+	currLine = currLine[1:] // remove first "tsuru"
+	spacedcurrLine := strings.Join(currLine, " ")
 
 	counter := map[string]int{}
 	for cmdName, comm := range m.Commands {
@@ -30,9 +30,9 @@ func getSuggestions(m *cmd.Manager, compLine []string) []string {
 		spacedCommand := strings.ReplaceAll(cmdName, "-", " ")
 		splitCommand := strings.Split(cmdName, "-")
 
-		if strings.HasPrefix(spacedCommand, spacedCompLine) &&
-			len(splitCommand) >= len(compLine) {
-			counter[splitCommand[len(compLine)-1]] += 1
+		if strings.HasPrefix(spacedCommand, spacedcurrLine) &&
+			len(splitCommand) >= len(currLine) {
+			counter[splitCommand[len(currLine)-1]] += 1
 		}
 	}
 
@@ -45,13 +45,13 @@ func getSuggestions(m *cmd.Manager, compLine []string) []string {
 }
 
 func handleAutocomplete() bool {
-	compLine := os.Getenv("COMP_LINE")
-	if compLine == "" {
+	currLine := os.Getenv("AUTOCOMPLETE_CURRENT_LINE")
+	if currLine == "" {
 		return false
 	}
-	compLineSlice := strings.Split(compLine, " ")
+	currLineSlice := strings.Split(currLine, " ") // TODO: handle quotes
 
 	m := buildManager("tsuru")
-	fmt.Println(strings.Join(getSuggestions(m, compLineSlice), "\n"))
+	fmt.Println(strings.Join(getSuggestions(m, currLineSlice), "\n"))
 	return true
 }

--- a/tsuru/autocomplete_test.go
+++ b/tsuru/autocomplete_test.go
@@ -1,0 +1,85 @@
+// Copyright 2017 tsuru-client authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestGetSuggestions(c *check.C) {
+	manager = buildManager("tsuru")
+
+	tests := []struct {
+		AutocompLine  []string
+		PositiveMatch []string
+		NegativeMatch []string
+	}{
+		{
+			[]string{"tsuru", ""},
+			[]string{"app", "login", "logout", "user"},
+			[]string{"deploy", "list", ""},
+		},
+		{
+			[]string{"tsuru", "l"},
+			[]string{"login", "logout"},
+			[]string{"app", "deploy", "list", ""}},
+		{
+			[]string{"tsuru", "app", ""},
+			[]string{"build", "deploy", "info", "start", "stop"},
+			[]string{"app", ""}},
+		{
+			[]string{"tsuru", "app", "s"},
+			[]string{"start", "stop"},
+			[]string{"app", "", "build", "deploy", "info"}},
+		{
+			[]string{"tsuru", "app", "st"},
+			[]string{"start", "stop"},
+			[]string{"app", "", "build", "deploy", "info"}},
+		{
+			[]string{"tsuru", "app", "sta"},
+			[]string{"start"},
+			[]string{"app", "", "build", "deploy", "info", "stop"},
+		},
+	}
+
+	for _, test := range tests {
+		suggestions := getSuggestions(manager, test.AutocompLine)
+		for _, s := range test.PositiveMatch {
+			c.Assert(sliceContains(suggestions, s), check.Equals, true)
+		}
+		for _, s := range test.NegativeMatch {
+			c.Assert(sliceContains(suggestions, s), check.Equals, false)
+		}
+	}
+}
+
+func (s *S) TestGetSuggestionsWrongInput(c *check.C) {
+	manager = buildManager("tsuru")
+
+	tests := []struct {
+		AutocompLine []string
+	}{
+		{[]string{"tsuru"}},
+		{[]string{"tsuru", "\"app "}},
+		{[]string{"tsuru", "'app"}},
+		{[]string{"tsuru", "\"'app"}},
+		{[]string{"tsuru", "\"'app'"}},
+		{[]string{"tsuru", "\"'app\""}}, // valid, but no suggestion should be given
+	}
+
+	for _, test := range tests {
+		suggestions := getSuggestions(manager, test.AutocompLine)
+		c.Assert(len(suggestions), check.Equals, 0, check.Commentf("test command: %v", test.AutocompLine))
+	}
+}
+
+func sliceContains(sStr []string, s string) bool {
+	for _, sStr := range sStr {
+		if sStr == s {
+			return true
+		}
+	}
+	return false
+}

--- a/tsuru/main.go
+++ b/tsuru/main.go
@@ -248,6 +248,9 @@ func recoverCmdPanicExitError() {
 
 func main() {
 	defer recoverCmdPanicExitError()
+	if handleAutocomplete() {
+		return
+	}
 
 	if inDockerMachineDriverMode() {
 		err := dockermachine.RunDriver(os.Getenv(localbinary.PluginEnvDriverName))


### PR DESCRIPTION
Adding a shell agnostic autocomplete.

This implies using a small wrapper written for a specific shell (bash, zsh, fish), but any autocomplete is performed inside the tsuru-client binary.
This add the possibility to easily extend the autocomplete feature within the Go codebase. 
One clear useful autocomplete would be to suggest apps when running `tsuru app info -a <APP(autocomplete...)> `

This PR include autocomplete for:
- [x] commands
- [x] subcommands
- [ ] flags
- [ ] possible arguments (eg: `app info -a <autocomplete>`)

This PR includes shell wrapper for:
- [x] bash
- [x] zsh
- [x] fish
- [ ] powershell

---

Although the autocomplete function is not full-featured, it is 100% functional with the included features, thus being considered for a merge