### PR TITLE
fix: handle path as root dir when user passes a single dir

### DIFF
--- a/tsuru/client/archiver_unix_test.go
+++ b/tsuru/client/archiver_unix_test.go
@@ -164,3 +164,18 @@ func (s *S) TestArchive_FilesOnly_MultipleDirs(c *check.C) {
 	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/file1.txt" as it already exists in the current directory.(.*)`)
 	c.Assert(stderr.String(), check.Matches, `(?s)(.*)Skipping file "testdata/deploy2/file2.txt" as it already exists in the current directory.(.*)`)
 }
+
+func (s *S) TestArchive_SingleDirectory_NoFilesOnly(c *check.C) {
+	var b bytes.Buffer
+	err := Archive(&b, false, []string{"./testdata/deploy"}, ArchiveOptions{Stderr: io.Discard})
+	c.Assert(err, check.IsNil)
+
+	got := extractFiles(s.t, c, &b)
+	expected := []miniFile{
+		{Name: "directory", Type: tar.TypeDir},
+		{Name: "directory/file.txt", Type: tar.TypeReg, Data: []byte("wat\n")},
+		{Name: "file1.txt", Type: tar.TypeReg, Data: []byte("something happened\n")},
+		{Name: "file2.txt", Type: tar.TypeReg, Data: []byte("twice\n")},
+	}
+	c.Assert(got, check.DeepEquals, expected)
+}

--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -318,9 +318,8 @@ func (s *S) TestDeploy_Run_UsingDockerfile(c *check.C) {
 			defer file.Close()
 			files := extractFiles(s.t, c, file)
 			c.Assert(files, check.DeepEquals, []miniFile{
-				{Name: filepath.Join("testdata", "deploy4"), Type: tar.TypeDir},
-				{Name: filepath.Join("testdata", "deploy4", "Dockerfile"), Type: tar.TypeReg, Data: []byte("FROM busybox:latest\n\nCOPY ./app.sh /usr/local/bin/\n")},
-				{Name: filepath.Join("testdata", "deploy4", "app.sh"), Type: tar.TypeReg, Data: []byte("echo \"Starting my application :P\"\n")},
+				{Name: filepath.Join("Dockerfile"), Type: tar.TypeReg, Data: []byte("FROM busybox:latest\n\nCOPY ./app.sh /usr/local/bin/\n")},
+				{Name: filepath.Join("app.sh"), Type: tar.TypeReg, Data: []byte("echo \"Starting my application :P\"\n")},
 			})
 
 			return req.Method == "POST" && strings.HasSuffix(req.URL.Path, "/apps/my-app/deploy")


### PR DESCRIPTION
This PR re-implements the same behavior from `tsuru`'s older versions when user passes a single directory to app-build, app-deploy  command arguments.

Example:
```
tsuru app deploy ... ./path/to/dir
```
All the content within `./path/to/dir` is compressed as the root directory in the `archive.tar.gz` file.