### PR TITLE
Fix for Dockerfile smell DL3007

### DIFF
--- a/tsuru/client/deploy_test.go
+++ b/tsuru/client/deploy_test.go
@@ -311,14 +311,14 @@ func (s *S) TestDeploy_Run_UsingDockerfile(c *check.C) {
 				defer req.Body.Close()
 			}
 			c.Assert(req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
-			c.Assert(req.FormValue("dockerfile"), check.Equals, "FROM busybox:latest\n\nCOPY ./app.sh /usr/local/bin/\n")
+			c.Assert(req.FormValue("dockerfile"), check.Equals, "FROM busybox:1.36.0-glibc\n\nCOPY ./app.sh /usr/local/bin/\n")
 
 			file, _, nerr := req.FormFile("file")
 			c.Assert(nerr, check.IsNil)
 			defer file.Close()
 			files := extractFiles(s.t, c, file)
 			c.Assert(files, check.DeepEquals, []miniFile{
-				{Name: filepath.Join("Dockerfile"), Type: tar.TypeReg, Data: []byte("FROM busybox:latest\n\nCOPY ./app.sh /usr/local/bin/\n")},
+				{Name: filepath.Join("Dockerfile"), Type: tar.TypeReg, Data: []byte("FROM busybox:1.36.0-glibc\n\nCOPY ./app.sh /usr/local/bin/\n")},
 				{Name: filepath.Join("app.sh"), Type: tar.TypeReg, Data: []byte("echo \"Starting my application :P\"\n")},
 			})
 

--- a/tsuru/client/testdata/deploy4/Dockerfile
+++ b/tsuru/client/testdata/deploy4/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox:latest
+FROM busybox:1.36.0-glibc
 
 COPY ./app.sh /usr/local/bin/


### PR DESCRIPTION
Hi!
The Dockerfile placed at "tsuru/client/testdata/deploy4/Dockerfile" contains the best practice violation [DL3007](https://github.com/hadolint/hadolint/wiki/DL3007) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3007 occurs when the tag "latest" is used instead of a specific version tag for the base image.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the base image in order to replace the "latest" tag. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance