### PR TITLE
bugfix: Missing confirmation input message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/tsuru/gnuflag v0.0.0-20151217162021-86b8c1b864aa
 	github.com/tsuru/go-tsuruclient v0.0.0-20240409125509-22a1e08326f4
 	github.com/tsuru/tablecli v0.0.0-20190131152944-7ded8a3383c6
-	github.com/tsuru/tsuru v0.0.0-20240411165438-543d3861334a
+	github.com/tsuru/tsuru v0.0.0-20240430173126-10560a3c53fd
 	golang.org/x/net v0.20.0
 	golang.org/x/oauth2 v0.16.0
 	golang.org/x/sys v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -681,6 +681,10 @@ github.com/tsuru/tablecli v0.0.0-20190131152944-7ded8a3383c6 h1:1XDdWFAjIbCSG1Oj
 github.com/tsuru/tablecli v0.0.0-20190131152944-7ded8a3383c6/go.mod h1:ztYpOhW+u1k21FEqp7nZNgpWbr0dUKok5lgGCZi+1AQ=
 github.com/tsuru/tsuru v0.0.0-20240411165438-543d3861334a h1:O0fPdqtXD4RQXaptD1AjezS/4Ryo5Fxjrm38jKZRYkE=
 github.com/tsuru/tsuru v0.0.0-20240411165438-543d3861334a/go.mod h1:QxMVXEjpb6mPnlaLMQdxJ3XCg+vOa4/MwZWLk3/naec=
+github.com/tsuru/tsuru v0.0.0-20240426210150-8ecd7f486345 h1:A6SbQLCBGgdJOKoXUrUmiCDVLNyy+cHV3omW9vgua8M=
+github.com/tsuru/tsuru v0.0.0-20240426210150-8ecd7f486345/go.mod h1:QxMVXEjpb6mPnlaLMQdxJ3XCg+vOa4/MwZWLk3/naec=
+github.com/tsuru/tsuru v0.0.0-20240430173126-10560a3c53fd h1:Al7qvBMn76Pb3Ci3AzULVTNUlv2SIn6MtjrLfbM0dlg=
+github.com/tsuru/tsuru v0.0.0-20240430173126-10560a3c53fd/go.mod h1:QxMVXEjpb6mPnlaLMQdxJ3XCg+vOa4/MwZWLk3/naec=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/tsuru/admin/cluster.go
+++ b/tsuru/admin/cluster.go
@@ -458,7 +458,6 @@ func (c *ClusterRemove) Info() *cmd.Info {
 }
 
 func (c *ClusterRemove) Run(ctx *cmd.Context) error {
-	ctx.RawOutput()
 	name := ctx.Args[0]
 	if !c.Confirm(ctx, fmt.Sprintf("Are you sure you want to remove cluster \"%s\"?", name)) {
 		return nil

--- a/tsuru/client/apps.go
+++ b/tsuru/client/apps.go
@@ -351,7 +351,6 @@ remove it (you are able to remove any app that you see in [[tsuru app list]]).`,
 }
 
 func (c *AppRemove) Run(context *cmd.Context) error {
-	context.RawOutput()
 	appName := c.Flags().Lookup("app").Value.String()
 	if appName == "" {
 		return errors.New("Please use the -a/--app flag to specify which app you want to remove.")

--- a/tsuru/client/deploy.go
+++ b/tsuru/client/deploy.go
@@ -408,7 +408,6 @@ func (c *AppDeployRollback) Info() *cmd.Info {
 }
 
 func (c *AppDeployRollback) Run(context *cmd.Context) error {
-	context.RawOutput()
 	appName, err := c.AppName()
 	if err != nil {
 		return err


### PR DESCRIPTION
Using the `tsuru-client` sometimes we can't see the confirmation input before entering the answer.

How to reproduce:
```sh
# normal behaviour
$ tsuru app remove -a gvicentin-static
Are you sure you want to remove app "gvicentin-static"? (y/n) n
Abort.

# bug happens not only here but with some other commands too
$ tsuru service instance remove rpaasv2-be gvicentin-be
n
Are you sure you want to remove the instance "gvicentin-be"? (y/n) Abort.
````

Since every confirmation input should not use pagination, we can call the RawOutput function to fix this weird behaviour. 
Dependency PR: https://github.com/tsuru/tsuru/pull/2693