### PR TITLE
feat: Add --tag flag to filter services in tsuru service list

### DIFF
--- a/tsuru/client/services.go
+++ b/tsuru/client/services.go
@@ -177,9 +177,11 @@ func (s ServiceList) Run(ctx *cmd.Context) error {
 	if hasPool {
 		header = append(header, "Pool")
 	}
+	hasServiceWithInstances := false
 	table.Headers = tablecli.Row(header)
 	for _, s := range services {
 		for _, instance := range s.ServiceInstances {
+			hasServiceWithInstances = true
 			row := []string{s.Service, instance.Name}
 			if hasPool {
 				row = append(row, instance.Pool)
@@ -187,6 +189,9 @@ func (s ServiceList) Run(ctx *cmd.Context) error {
 			r := tablecli.Row(row)
 			table.AddRow(r)
 		}
+	}
+	if !hasServiceWithInstances {
+		return nil
 	}
 
 	_, err = ctx.Stdout.Write(table.Bytes())

--- a/tsuru/client/services.go
+++ b/tsuru/client/services.go
@@ -34,6 +34,7 @@ type serviceFilter struct {
 	plan      string
 	service   string
 	teamOwner string
+	tags      cmd.StringSliceFlag
 }
 
 func (f *serviceFilter) queryString() (url.Values, error) {
@@ -52,6 +53,9 @@ func (f *serviceFilter) queryString() (url.Values, error) {
 	}
 	if f.service != "" {
 		result.Set("service", f.service)
+	}
+	for _, tag := range f.tags {
+		result.Add("tag", tag)
 	}
 	return result, nil
 }
@@ -88,7 +92,9 @@ func (c *ServiceList) Flags() *gnuflag.FlagSet {
 		c.fs.BoolVar(&c.simplified, "q", false, "Display only service instances name")
 		c.fs.BoolVar(&c.json, "json", false, "Display in JSON format")
 		c.fs.BoolVar(&c.justServiceNames, "j", false, "Display just service names")
-
+		tagMessage := "Filter services by tag. Can be used multiple times"
+		c.fs.Var(&c.filter.tags, "tag", tagMessage)
+		c.fs.Var(&c.filter.tags, "g", tagMessage)
 	}
 	return c.fs
 }

--- a/tsuru/client/services_test.go
+++ b/tsuru/client/services_test.go
@@ -178,11 +178,11 @@ func (s *S) TestServiceListWithTags(c *check.C) {
 	trans := cmdtest.ConditionalTransport{
 		Transport: cmdtest.Transport{Message: string(output), Status: http.StatusOK},
 		CondFunc: func(req *http.Request) bool {
-			err := req.ParseForm()
+			err = req.ParseForm()
 			c.Assert(err, check.IsNil)
 
 			tags := req.Form["tag"]
-			c.Assert(tags, check.DeepEquals, []string{"tag1", "--tag"})
+			c.Assert(tags, check.DeepEquals, []string{"tag1", "tag2"})
 
 			return strings.HasSuffix(req.URL.Path, "/services/instances")
 		},

--- a/tsuru/client/services_test.go
+++ b/tsuru/client/services_test.go
@@ -163,7 +163,6 @@ func (s *S) TestServiceListWithTags(c *check.C) {
 			ServiceInstances: []service.ServiceInstance{
 				{
 					Name: "mysql01",
-					Tags: []string{"production"},
 				},
 			},
 		},
@@ -171,7 +170,7 @@ func (s *S) TestServiceListWithTags(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	ctx := cmd.Context{
-		Args:   []string{"--tag", "production"},
+		Args:   []string{},
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
@@ -183,19 +182,15 @@ func (s *S) TestServiceListWithTags(c *check.C) {
 			c.Assert(err, check.IsNil)
 
 			tags := req.Form["tag"]
-			c.Assert(tags, check.DeepEquals, []string{"production"})
+			c.Assert(tags, check.DeepEquals, []string{"tag1", "--tag"})
 
 			return strings.HasSuffix(req.URL.Path, "/services/instances")
 		},
 	}
-	serviceList := &ServiceList{
-		filter: serviceFilter{
-			tags: cmd.StringSliceFlag{"production"},
-		},
-	}
 	s.setupFakeTransport(&trans)
-
-	err = serviceList.Run(&ctx)
+	command := ServiceList{}
+	command.Flags().Parse(true, []string{"--tag", "tag1", "--tag", "tag2"})
+	err = command.Run(&ctx)
 	c.Assert(err, check.IsNil)
 
 	table := stdout.String()


### PR DESCRIPTION
The tsuru-client can now use the tsuru API's tag filtering feature for services instances. The "tsuru service list" command now supports the -g or --tag flags like `tsuru service list -g key=value`. I based this improvement on the way tsuru-client does the `tsuru app list` command.