### PR TITLE
Fix: Cert issuer validation for apps

### DIFF
--- a/tsuru/admin/pool.go
+++ b/tsuru/admin/pool.go
@@ -463,11 +463,24 @@ func (c *PoolConstraintSet) Info() *cmd.Info {
 
 Examples:
 
-[[tsuru pool-constraint-set dev_pool team "*" # allows every team to use the pool "dev_pool" ]]
-[[tsuru pool-constraint-set "dev_*" router prod_router --blacklist # disallows "prod_router" to be used on every pool with "dev_" prefix ]]
-[[tsuru pool-constraint-set prod_pool team team2 team3 --append # adds "team2" and "team3" to the list of teams allowed to use pool "prod_pool"]]
-[[tsuru pool-constraint-set prod_pool service service1 service2 --append # adds "service1" and "service2" to the list of services allowed to be used on pool "prod_pool"]]
-[[tsuru pool-constraint-set prod_pool service service1 --blacklist # disallows "service1" to be used on pool "prod_pool"]]`,
+  tsuru pool-constraint-set dev_pool team "*" 
+      # Allows every team to use the pool "dev_pool".
+
+  tsuru pool-constraint-set "dev_*" router prod_router --blacklist
+	  # Disallows "prod_router" to be used on pools with "dev_" prefix.
+
+  tsuru pool-constraint-set dev_pool cert-issuer letsencrypt digicert 
+      # Constraint every app in the the pool "dev_pool" to use certificate issuer from letsencrypt or digicert.
+
+  tsuru pool-constraint-set "dev_*" router prod_router --blacklist
+      # Disallows "prod_router" to be used on pools with "dev_" prefix.
+
+  tsuru pool-constraint-set prod_pool service service1 service2 --append
+      # Adds "service1" and "service2" to the list of services allowed to use pool "prod_pool".
+	  
+  tsuru pool-constraint-set prod_pool service service1 service2 --blacklist --append
+	  # Adds "service1" and "service2" to the list of services disallowed to use pool "prod_pool".`,
+
 		MinArgs: 2,
 	}
 }

--- a/tsuru/admin/pool.go
+++ b/tsuru/admin/pool.go
@@ -464,22 +464,22 @@ func (c *PoolConstraintSet) Info() *cmd.Info {
 Examples:
 
   tsuru pool-constraint-set dev_pool team "*" 
-      # Allows every team to use the pool "dev_pool".
+	# Allows every team to use the pool "dev_pool".
 
   tsuru pool-constraint-set "dev_*" router prod_router --blacklist
-	  # Disallows "prod_router" to be used on pools with "dev_" prefix.
+	# Disallows "prod_router" to be used on pools with "dev_" prefix.
 
   tsuru pool-constraint-set dev_pool cert-issuer letsencrypt digicert 
-      # Constraint every app in the the pool "dev_pool" to use certificate issuer from letsencrypt or digicert.
+	# Constraint every app in the the pool "dev_pool" to use certificate issuer from letsencrypt or digicert.
 
   tsuru pool-constraint-set "dev_*" router prod_router --blacklist
-      # Disallows "prod_router" to be used on pools with "dev_" prefix.
+	# Disallows "prod_router" to be used on pools with "dev_" prefix.
 
   tsuru pool-constraint-set prod_pool service service1 service2 --append
-      # Adds "service1" and "service2" to the list of services allowed to use pool "prod_pool".
+	# Adds "service1" and "service2" to the list of services allowed to use pool "prod_pool".
 	  
   tsuru pool-constraint-set prod_pool service service1 service2 --blacklist --append
-	  # Adds "service1" and "service2" to the list of services disallowed to use pool "prod_pool".`,
+  	# Adds "service1" and "service2" to the list of services disallowed to use pool "prod_pool".`,
 
 		MinArgs: 2,
 	}


### PR DESCRIPTION
Update tsuru client for the fix of [PR #2747](https://github.com/tsuru/tsuru/pull/2747) of Tsuru API

- [x]  tsuru-client deal with new pool-constraint type for cert issuers;
- [x]  tsuru-client deal with pools-constraints when create a new cert-issuer for a Tsuru app;
- [ ]  ~~tsuru-client deal with error when create a new cert-issuer for a App when the issuer already exist.~~