### PR TITLE
[feat] Add `alias` and `config` subcommand

### DIFF
--- a/tsuru/client/config.go
+++ b/tsuru/client/config.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -13,7 +14,7 @@ type AppConfig struct {
 	Aliases Aliases `json:"aliases"`
 }
 
-type Aliases []Alias
+type Aliases []*Alias
 
 type Alias struct {
 	Source []string `json:"source"`
@@ -34,7 +35,7 @@ func (a *Alias) MatchesSource(source []string) bool {
 func (a *Aliases) Has(source []string) (*Alias, bool) {
 	for _, alias := range *a {
 		if alias.MatchesSource(source) {
-			return &alias, true
+			return alias, true
 		}
 	}
 
@@ -49,14 +50,15 @@ func (a *Aliases) Add(source, target []string) {
 
 	alias, exists := a.Has(source)
 	if exists {
-		alias.Source = source
-	} else {
-		alias = &Alias{
-			Source: source,
-			Target: target,
-		}
+		alias.Target = target
+		return
 	}
-	*a = append(*a, *alias)
+
+	alias = &Alias{
+		Source: source,
+		Target: target,
+	}
+	*a = append(*a, alias)
 }
 
 // Remove will remove an alias to the config, if it exists.
@@ -79,12 +81,12 @@ func configFilePath() (string, error) {
 		return "", err
 	}
 
-	configPath := home + "/.config/tsuru/"
+	configPath := filepath.Join(home, ".config", "tsuru")
 	if err := os.MkdirAll(configPath, 0755); err != nil {
 		return "", err
 	}
 
-	return configPath + "config.json", nil
+	return filepath.Join(configPath, "config.json"), nil
 }
 
 func GetConfig() (*AppConfig, error) {

--- a/tsuru/client/config.go
+++ b/tsuru/client/config.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"github.com/tsuru/tsuru-client/tsuru/cmd"
+)
+
+type AppConfig struct {
+	Aliases Aliases `json:"aliases"`
+}
+
+type Aliases []Alias
+
+type Alias struct {
+	Source []string `json:"source"`
+	Target []string `json:"target"`
+}
+
+// MatchesSource checks if the provided source matches the alias source.
+func (a *Alias) MatchesSource(source []string) bool {
+	for i, item := range a.Source {
+		if item != source[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Has returns the alias matching the provided source, if it exists.
+func (a *Aliases) Has(source []string) (*Alias, bool) {
+	for _, alias := range *a {
+		if alias.MatchesSource(source) {
+			return &alias, true
+		}
+	}
+
+	return nil, false
+}
+
+// Add will add an alias to the config, updating the entry if it already exists.
+func (a *Aliases) Add(source, target []string) {
+	if len(source) == 0 || len(target) == 0 {
+		return
+	}
+
+	alias, exists := a.Has(source)
+	if !exists {
+		alias = &Alias{
+			Source: source,
+			Target: target,
+		}
+	}
+	*a = append(*a, *alias)
+}
+
+// Remove will remove an alias to the config, if it exists.
+func (a *Aliases) Remove(source []string) {
+	for i, alias := range *a {
+		if alias.MatchesSource(source) {
+			*a = append((*a)[:i], (*a)[i+1:]...)
+			break
+		}
+	}
+}
+
+func configFilePath() (string, error) {
+	if envPath := os.Getenv("TSURU_CONFIG_FILE"); envPath != "" {
+		return envPath, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	configPath := home + "/.config/tsuru/"
+	if err := os.MkdirAll(configPath, 0755); err != nil {
+		return "", err
+	}
+
+	return configPath + "config.json", nil
+}
+
+func GetConfig() (*AppConfig, error) {
+	config := AppConfig{
+		Aliases: make(Aliases, 0),
+	}
+
+	configPath, err := configFilePath()
+	if err != nil {
+		return nil, err
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &config, nil
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(content, &config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func (config *AppConfig) Save() error {
+	configPath, err := configFilePath()
+	if err != nil {
+		return err
+	}
+
+	content, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(configPath, content, 0644)
+}
+
+type ConfigAlias struct {
+	fs     *pflag.FlagSet
+	delete bool
+}
+
+func (c *ConfigAlias) Flags() *pflag.FlagSet {
+	if c.fs == nil {
+		c.fs = pflag.NewFlagSet("config-alias", pflag.ExitOnError)
+
+		desc := "remove the provided alias instead of adding it"
+		c.fs.BoolVarP(&c.delete, "delete", "d", false, desc)
+	}
+	return c.fs
+}
+
+func (c *ConfigAlias) Run(ctx *cmd.Context) error {
+	config, err := GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if c.delete {
+		source := strings.Split(ctx.Args[0], " ")
+		config.Aliases.Remove(source)
+	} else {
+		source := strings.Split(ctx.Args[0], " ")
+		target := strings.Split(ctx.Args[1], " ")
+		config.Aliases.Add(source, target)
+	}
+
+	return config.Save()
+}
+
+func (ConfigAlias) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:  "config-alias",
+		Usage: "<alias> <command> [--delete/-d]",
+		Desc: `Add an alias to a tsuru command. This allows you to create custom shortcuts for tsuru commands, making it easier to use the CLI.
+Examples:
+
+# make 'deploy' map to 'app deploy'
+$ tsuru config alias "app deploy" "deploy"
+$ tsuru deploy <app-name>
+
+# create a shorthand for 'app info':
+$ tsuru config alias "app info" "ai"
+$ tsuru ai <app-name>
+`,
+	}
+}

--- a/tsuru/client/config.go
+++ b/tsuru/client/config.go
@@ -48,7 +48,9 @@ func (a *Aliases) Add(source, target []string) {
 	}
 
 	alias, exists := a.Has(source)
-	if !exists {
+	if exists {
+		alias.Source = source
+	} else {
 		alias = &Alias{
 			Source: source,
 			Target: target,

--- a/tsuru/client/config_test.go
+++ b/tsuru/client/config_test.go
@@ -1,54 +1,65 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
-	"testing"
+
+	"github.com/tsuru/tsuru-client/tsuru/cmd"
+	check "gopkg.in/check.v1"
 )
 
-func TestAliases(t *testing.T) {
+func (s *S) TestAliases(c *check.C) {
 	a := Aliases{}
-	src := []string{"app", "deploy"}
-	target := []string{"deploy"}
+	src := []string{"deploy"}
+	target := []string{"app", "deploy"}
 
 	a.Add(src, target)
-	if len(a) != 1 {
-		t.Fatalf("expected 1 alias, got %d", len(a))
-	}
+	c.Assert(a, check.HasLen, 1)
 
 	found, ok := a.Has(src)
-	if !ok {
-		t.Fatal("alias not found")
-	}
-	if !reflect.DeepEqual(found.Target, target) {
-		t.Errorf("expected target %v, got %v", target, found.Target)
-	}
+	c.Assert(ok, check.Equals, true)
+	c.Assert(found.Source, check.DeepEquals, src)
+	c.Assert(found.Target, check.DeepEquals, target)
+
+	found, ok = a.Has([]string{"unexistent"})
+	c.Assert(ok, check.Equals, false)
+	c.Assert(found, check.IsNil)
+
+	override := []string{"app", "shell"}
+	a.Add(src, override)
+	found, ok = a.Has(src)
+	c.Assert(ok, check.Equals, true)
+	c.Assert(found.Source, check.DeepEquals, src)
+	c.Assert(found.Target, check.DeepEquals, override)
 
 	a.Remove(src)
-	if len(a) != 0 {
-		t.Errorf("expected 0 aliases, got %d", len(a))
-	}
+	c.Assert(a, check.HasLen, 0)
 }
 
-func TestConfigFilePath(t *testing.T) {
-	os.Setenv("TSURU_CONFIG_FILE", "/tmp/tsuru/config.json")
-	defer os.Unsetenv("TSURU_CONFIG_FILE")
-
+func (s *S) TestConfigFilePath(c *check.C) {
+	homeDir, err := os.UserHomeDir()
+	c.Assert(err, check.IsNil)
+	expectedPath := filepath.Join(homeDir, ".config", "tsuru", "config.json")
 	path, err := configFilePath()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if path != "/tmp/tsuru/config.json" {
-		t.Errorf("expected /tmp/tsuru/config.json, got %s", path)
-	}
+	c.Assert(err, check.IsNil)
+	c.Assert(expectedPath, check.Equals, path)
+
+	tmpDir, err := os.MkdirTemp("", "tsuru-test")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(tmpDir)
+	expectedPath = filepath.Join(tmpDir, "config.json")
+	os.Setenv("TSURU_CONFIG_FILE", expectedPath)
+	defer os.Unsetenv("TSURU_CONFIG_FILE")
+	path, err = configFilePath()
+	c.Assert(err, check.IsNil)
+	c.Assert(path, check.Equals, expectedPath)
 }
 
-func TestSaveAndGetConfig(t *testing.T) {
+func (s *S) TestSaveAndGetConfig(c *check.C) {
 	tmpDir, err := os.MkdirTemp("", "tsuru-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	c.Assert(err, check.IsNil)
 	defer os.RemoveAll(tmpDir)
 
 	configPath := filepath.Join(tmpDir, "config.json")
@@ -62,19 +73,102 @@ func TestSaveAndGetConfig(t *testing.T) {
 	}
 
 	err = config.Save()
-	if err != nil {
-		t.Fatalf("failed to save config: %v", err)
-	}
+	c.Assert(err, check.IsNil)
 
 	loadedConfig, err := GetConfig()
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
+	c.Assert(err, check.IsNil)
+	c.Assert(loadedConfig.Aliases, check.HasLen, 1)
+	c.Assert(loadedConfig.Aliases[0].Target, check.DeepEquals, []string{"cmd"})
+}
 
-	if len(loadedConfig.Aliases) != 1 {
-		t.Errorf("expected 1 alias, got %d", len(loadedConfig.Aliases))
+func (s *S) TestAliasInfo(c *check.C) {
+	var cmd ConfigAlias
+	c.Assert(cmd.Info(), check.NotNil)
+}
+
+func (s *S) TestAliasRun(c *check.C) {
+	tmpDir, err := os.MkdirTemp("", "tsuru-test")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(tmpDir)
+	configPath := filepath.Join(tmpDir, "config.json")
+	os.Setenv("TSURU_CONFIG_FILE", configPath)
+	defer os.Unsetenv("TSURU_CONFIG_FILE")
+
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Args:   []string{"deploy", "app deploy"},
 	}
-	if !reflect.DeepEqual(loadedConfig.Aliases[0].Target, []string{"cmd"}) {
-		t.Errorf("expected alias cmd, got %v", loadedConfig.Aliases[0].Target)
+	command := ConfigAlias{}
+	command.Flags().Parse([]string{})
+	err = command.Run(&context)
+	c.Assert(err, check.IsNil)
+
+	content, err := os.ReadFile(configPath)
+	c.Assert(err, check.IsNil)
+	var appConfig AppConfig
+	err = json.Unmarshal(content, &appConfig)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(appConfig.Aliases, check.HasLen, 1)
+	c.Assert(appConfig.Aliases[0].Source, check.DeepEquals, []string{"deploy"})
+	c.Assert(appConfig.Aliases[0].Target, check.DeepEquals, []string{"app", "deploy"})
+
+	context.Args = []string{"deploy", "override"}
+	command = ConfigAlias{}
+	command.Flags().Parse([]string{})
+	err = command.Run(&context)
+	c.Assert(err, check.IsNil)
+
+	content, err = os.ReadFile(configPath)
+	c.Assert(err, check.IsNil)
+	err = json.Unmarshal(content, &appConfig)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(appConfig.Aliases, check.HasLen, 1)
+	c.Assert(appConfig.Aliases[0].Source, check.DeepEquals, []string{"deploy"})
+	c.Assert(appConfig.Aliases[0].Target, check.DeepEquals, []string{"override"})
+}
+
+func (s *S) TestAliasRemove(c *check.C) {
+	tmpDir, err := os.MkdirTemp("", "tsuru-test")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(tmpDir)
+	configPath := filepath.Join(tmpDir, "config.json")
+	os.Setenv("TSURU_CONFIG_FILE", configPath)
+	defer os.Unsetenv("TSURU_CONFIG_FILE")
+
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Args:   []string{"deploy", "app deploy"},
 	}
+	command := ConfigAlias{}
+	command.Flags().Parse([]string{})
+	err = command.Run(&context)
+	c.Assert(err, check.IsNil)
+
+	content, err := os.ReadFile(configPath)
+	c.Assert(err, check.IsNil)
+	var appConfig AppConfig
+	err = json.Unmarshal(content, &appConfig)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(appConfig.Aliases, check.HasLen, 1)
+	c.Assert(appConfig.Aliases[0].Source, check.DeepEquals, []string{"deploy"})
+
+	context.Args = []string{"deploy"}
+	command = ConfigAlias{}
+	command.Flags().Parse([]string{"--delete"})
+	err = command.Run(&context)
+	c.Assert(err, check.IsNil)
+
+	content, err = os.ReadFile(configPath)
+	c.Assert(err, check.IsNil)
+	err = json.Unmarshal(content, &appConfig)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(appConfig.Aliases, check.HasLen, 0)
 }

--- a/tsuru/client/config_test.go
+++ b/tsuru/client/config_test.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestAliases(t *testing.T) {
+	a := Aliases{}
+	src := []string{"app", "deploy"}
+	target := []string{"deploy"}
+
+	a.Add(src, target)
+	if len(a) != 1 {
+		t.Fatalf("expected 1 alias, got %d", len(a))
+	}
+
+	found, ok := a.Has(src)
+	if !ok {
+		t.Fatal("alias not found")
+	}
+	if !reflect.DeepEqual(found.Target, target) {
+		t.Errorf("expected target %v, got %v", target, found.Target)
+	}
+
+	a.Remove(src)
+	if len(a) != 0 {
+		t.Errorf("expected 0 aliases, got %d", len(a))
+	}
+}
+
+func TestConfigFilePath(t *testing.T) {
+	os.Setenv("TSURU_CONFIG_FILE", "/tmp/tsuru/config.json")
+	defer os.Unsetenv("TSURU_CONFIG_FILE")
+
+	path, err := configFilePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "/tmp/tsuru/config.json" {
+		t.Errorf("expected /tmp/tsuru/config.json, got %s", path)
+	}
+}
+
+func TestSaveAndGetConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tsuru-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.json")
+	os.Setenv("TSURU_CONFIG_FILE", configPath)
+	defer os.Unsetenv("TSURU_CONFIG_FILE")
+
+	config := AppConfig{
+		Aliases: Aliases{
+			{Source: []string{"test"}, Target: []string{"cmd"}},
+		},
+	}
+
+	err = config.Save()
+	if err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	loadedConfig, err := GetConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	if len(loadedConfig.Aliases) != 1 {
+		t.Errorf("expected 1 alias, got %d", len(loadedConfig.Aliases))
+	}
+	if !reflect.DeepEqual(loadedConfig.Aliases[0].Target, []string{"cmd"}) {
+		t.Errorf("expected alias cmd, got %v", loadedConfig.Aliases[0].Target)
+	}
+}

--- a/tsuru/cmd/v2/root.go
+++ b/tsuru/cmd/v2/root.go
@@ -39,6 +39,9 @@ func setupPFlagsAndCommands(rootCmd *cobra.Command) {
 
 	rootCmd.PersistentFlags().Int("verbosity", 0, "Verbosity level: 1 => print HTTP requests; 2 => print HTTP requests/responses")
 	defaultViper.BindPFlag("verbosity", rootCmd.PersistentFlags().Lookup("verbosity"))
+
+	rootCmd.PersistentFlags().String("config", "", "Tsuru configuration file path to use")
+	defaultViper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
 }
 
 func rootPersistentPreRun(cmd *cobra.Command, args []string) {
@@ -49,6 +52,11 @@ func rootPersistentPreRun(cmd *cobra.Command, args []string) {
 
 	if v, err := cmd.Flags().GetInt("verbosity"); v > 0 && err == nil {
 		os.Setenv("TSURU_VERBOSITY", strconv.Itoa(v))
+	}
+
+	if c := cmd.Flags().Lookup("config"); c != nil && c.Value.String() != "" {
+		filePath := c.Value.String()
+		os.Setenv("TSURU_CONFIG_FILE", filePath)
 	}
 }
 

--- a/tsuru/main.go
+++ b/tsuru/main.go
@@ -95,6 +95,27 @@ func buildManager(stdout, stderr io.Writer) *cmd.ManagerV2 {
 		standards.FlagRouter:   completions.RouterNameCompletionFunc,
 	})
 
+	config, err := client.GetConfig()
+	if err != nil {
+		message := fmt.Sprintf("Could not read config file: %s\n", err.Error())
+		panic(message)
+	}
+
+	// Check for aliases first. Since aliases are user defined values, they should
+	// be prioritized, even if it means overriding a command that already exists.
+	if len(os.Args) > 1 {
+		args := os.Args[1:] // ignore app name argument
+		alias, exists := config.Aliases.Has(args)
+		if exists {
+			// replace the original arguments with the alias command
+			otherArgsStartIndex := len(alias.Source) + 1
+			newArgs := []string{os.Args[0]}
+			newArgs = append(newArgs, alias.Target...)
+			newArgs = append(newArgs, os.Args[otherArgsStartIndex:]...)
+			os.Args = newArgs
+		}
+	}
+
 	m.RegisterTopic("app", `App is a program source code running on Tsuru.`)
 
 	m.Register(&auth.Login{})
@@ -346,6 +367,12 @@ Services aren’t managed by tsuru, but by their creators.`)
 	m.Register(&client.AppVersionRouterRemove{})
 
 	m.Register(client.UserInfo{})
+
+	m.RegisterTopic("config", `Manage tsuru client configuration. Config file is expected at $HOME/.config/tsuru/config.json
+
+You are allowed to pass a custom path using the --config flag or by setting the "TSURU_CONFIG_PATH" environment variable.
+`)
+	m.Register(&client.ConfigAlias{})
 
 	m.RegisterTopic("autoscale", "Manage autoscaling of application units.")
 	m.RegisterTopic("unit-autoscale", "Manage autoscaling of application units.")

--- a/tsuru/main_test.go
+++ b/tsuru/main_test.go
@@ -93,6 +93,7 @@ func (s *S) TestCommandsRegistered(c *check.C) {
 		"service-create",
 		"service-destroy",
 		"service-doc-get",
+		"config-alias",
 	}
 
 	cobraCmd := manager.Cobra()


### PR DESCRIPTION
This PR adds a few things to the tsuru client. 

Mainly, it adds a `config alias` subcommand, which allows the user to set aliases for a command.
examples:
```sh
# create the alias
$ tsuru config alias shell "app shell -a"

# and then use it
$ tsuru shell my-app
```
Multiple word aliases are also supported.
```sh
$ tsuru config alias "isolated shell" "app shell -i -a"
$ tsuru isolated shell my-app
```
And, of course, removal of aliases are also possible.
```sh
# use either `--delete` or `-d`
$ tsuru config alias "my alias" --delete
```

I wasn't sure about adding a `alias list` command, so I ended up not adding it.

Every config is stored in a file that defaults to `$HOME/.config/tsuru/config.json`. I've also added a global `--config` flag that allows the user to set a custom path for the config file (or set the `TSURU_CONFIG_FILE` environment variable).

closes #259 