### PR TITLE
fix(auth): report OIDC auth errors accurately (error redirects, expired session)

### DIFF
--- a/tsuru/auth/oidc.go
+++ b/tsuru/auth/oidc.go
@@ -6,6 +6,7 @@ package auth
 
 import (
 	stdContext "context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -52,9 +53,26 @@ func oidcLogin(ctx *cmd.Context, loginInfo *authTypes.SchemeInfo) error {
 			finish <- true
 		}()
 
-		t, handlerErr := oauth2Config.Exchange(stdContext.Background(), r.URL.Query().Get("code"), oauth2.VerifierOption(pkceVerifier))
-
 		w.Header().Add("Content-Type", "text/html")
+
+		// RFC 6749 section 4.1.2.1: the authorization server may redirect
+		// back with an error instead of a code.
+		query := r.URL.Query()
+		if errCode := query.Get("error"); errCode != "" {
+			handlerErr := fmt.Errorf("authorization server returned an error: %s: %s", errCode, query.Get("error_description"))
+			fmt.Fprintf(ctx.Stderr, "Login failed: %v\n", handlerErr)
+			writeHTMLError(w, handlerErr)
+			return
+		}
+		code := query.Get("code")
+		if code == "" {
+			handlerErr := errors.New("authorization response missing 'code' parameter")
+			fmt.Fprintf(ctx.Stderr, "Login failed: %v\n", handlerErr)
+			writeHTMLError(w, handlerErr)
+			return
+		}
+
+		t, handlerErr := oauth2Config.Exchange(stdContext.Background(), code, oauth2.VerifierOption(pkceVerifier))
 
 		if handlerErr != nil {
 			writeHTMLError(w, handlerErr)

--- a/tsuru/auth/oidc.go
+++ b/tsuru/auth/oidc.go
@@ -81,7 +81,7 @@ func oidcLogin(ctx *cmd.Context, loginInfo *authTypes.SchemeInfo) error {
 
 		fmt.Fprintln(ctx.Stderr, "Successfully logged in via OIDC!")
 		tokenExpiry := time.Since(t.Expiry) * -1
-		fmt.Fprintf(ctx.Stderr, "The OIDC token will expiry in %s\n", tokenExpiry.Round(time.Second))
+		fmt.Fprintf(ctx.Stderr, "The OIDC token will expire in %s\n", tokenExpiry.Round(time.Second))
 
 		handlerErr = config.WriteTokenV2(config.TokenV2{
 			Scheme:       "oidc",

--- a/tsuru/auth/oidc_test.go
+++ b/tsuru/auth/oidc_test.go
@@ -73,6 +73,7 @@ func (s *S) TestOIDChLogin(c *check.C) {
 	})
 
 	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(context.Stderr.(*bytes.Buffer).String(), "The OIDC token will expire in"), check.Equals, true)
 	tokenV1, err := config.ReadTokenV1()
 	c.Assert(err, check.IsNil)
 	c.Assert(tokenV1, check.Equals, "mytoken")

--- a/tsuru/auth/oidc_test.go
+++ b/tsuru/auth/oidc_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/tsuru/go-tsuruclient/pkg/config"
@@ -92,4 +94,118 @@ func (s *S) TestOIDChLogin(c *check.C) {
 			},
 		},
 	})
+}
+
+func (s *S) TestOIDCLoginErrorRedirect(c *check.C) {
+	config.SetFileSystem(&fstest.RecordingFs{})
+
+	bodyCh := make(chan string, 1)
+	execut = &fakeExecutor{
+		DoExecute: func(opts exec.ExecuteOptions) error {
+			go func() {
+				time.Sleep(time.Second)
+				resp, err := http.Get("http://localhost:41001/?error=invalid_request&error_description=Invalid+scopes:+openid")
+				c.Assert(err, check.IsNil)
+				defer resp.Body.Close()
+				b, err := io.ReadAll(resp.Body)
+				c.Assert(err, check.IsNil)
+				bodyCh <- string(b)
+			}()
+			return nil
+		},
+	}
+
+	defer func() {
+		config.ResetFileSystem()
+		execut = nil
+	}()
+
+	var tokenEndpointCalls int32
+	fakeIDP := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&tokenEndpointCalls, 1)
+		rw.WriteHeader(http.StatusBadRequest)
+		rw.Write([]byte(`{"error":"invalid_grant","error_description":"Code not valid"}`))
+	}))
+	defer fakeIDP.Close()
+
+	stderr := &bytes.Buffer{}
+	context := &cmd.Context{
+		Stdout: &bytes.Buffer{},
+		Stderr: stderr,
+	}
+
+	err := oidcLogin(context, &auth.SchemeInfo{
+		Data: auth.SchemeData{
+			Port:     "41001",
+			TokenURL: fakeIDP.URL,
+			ClientID: "test-tsuru",
+			Scopes:   []string{"scope1"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	body := <-bodyCh
+	c.Assert(strings.Contains(body, "invalid_request"), check.Equals, true)
+	c.Assert(strings.Contains(body, "Invalid scopes: openid"), check.Equals, true)
+	c.Assert(strings.Contains(body, "invalid_grant"), check.Equals, false)
+	c.Assert(strings.Contains(stderr.String(), "invalid_request"), check.Equals, true)
+	c.Assert(strings.Contains(stderr.String(), "Invalid scopes: openid"), check.Equals, true)
+	c.Assert(atomic.LoadInt32(&tokenEndpointCalls), check.Equals, int32(0))
+
+	tokenV1, _ := config.ReadTokenV1()
+	c.Assert(tokenV1, check.Equals, "")
+}
+
+func (s *S) TestOIDCLoginMissingCode(c *check.C) {
+	config.SetFileSystem(&fstest.RecordingFs{})
+
+	bodyCh := make(chan string, 1)
+	execut = &fakeExecutor{
+		DoExecute: func(opts exec.ExecuteOptions) error {
+			go func() {
+				time.Sleep(time.Second)
+				resp, err := http.Get("http://localhost:41002/")
+				c.Assert(err, check.IsNil)
+				defer resp.Body.Close()
+				b, err := io.ReadAll(resp.Body)
+				c.Assert(err, check.IsNil)
+				bodyCh <- string(b)
+			}()
+			return nil
+		},
+	}
+
+	defer func() {
+		config.ResetFileSystem()
+		execut = nil
+	}()
+
+	var tokenEndpointCalls int32
+	fakeIDP := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&tokenEndpointCalls, 1)
+		rw.WriteHeader(http.StatusBadRequest)
+		rw.Write([]byte(`{"error":"invalid_grant","error_description":"Code not valid"}`))
+	}))
+	defer fakeIDP.Close()
+
+	stderr := &bytes.Buffer{}
+	context := &cmd.Context{
+		Stdout: &bytes.Buffer{},
+		Stderr: stderr,
+	}
+
+	err := oidcLogin(context, &auth.SchemeInfo{
+		Data: auth.SchemeData{
+			Port:     "41002",
+			TokenURL: fakeIDP.URL,
+			ClientID: "test-tsuru",
+			Scopes:   []string{"scope1"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	body := <-bodyCh
+	c.Assert(strings.Contains(body, "missing 'code' parameter"), check.Equals, true)
+	c.Assert(strings.Contains(stderr.String(), "missing 'code' parameter"), check.Equals, true)
+	c.Assert(atomic.LoadInt32(&tokenEndpointCalls), check.Equals, int32(0))
 }

--- a/tsuru/http/transport.go
+++ b/tsuru/http/transport.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tsuru/go-tsuruclient/pkg/config"
 	tsuruerr "github.com/tsuru/tsuru/errors"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -138,6 +139,8 @@ func detectClientError(err error) error {
 			return errors.Wrapf(e, "Error received from tsuru server (%s), %d", target, e.Code)
 		case x509.UnknownAuthorityError:
 			return errors.Wrapf(e, "Failed to connect to tsuru server (%s)", target)
+		case *oauth2.RetrieveError:
+			return errors.Wrapf(e, "your session has expired, please run \"tsuru login\" (%s)", target)
 		}
 		return errors.Wrapf(e, "Failed to connect to tsuru server (%s), it's probably down", target)
 	}

--- a/tsuru/http/transport_test.go
+++ b/tsuru/http/transport_test.go
@@ -2,10 +2,14 @@ package http
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/tsuru/tsuru-client/tsuru/cmd/cmdtest"
+	"golang.org/x/oauth2"
 	check "gopkg.in/check.v1"
 )
 
@@ -68,4 +72,22 @@ func (s *S) TestVerboseRoundTripperDumpRequestResponse2(c *check.C) {
 		"Success!\n"+
 		"*************************** </Response uri=\"/users\"> **********************************\n")
 
+}
+
+func (s *S) TestDetectClientErrorOAuth2RetrieveError(c *check.C) {
+	retrieveErr := &oauth2.RetrieveError{
+		ErrorCode:        "invalid_grant",
+		ErrorDescription: "Token is not active",
+	}
+	err := detectClientError(&url.Error{Op: "Get", URL: "https://tsuru.example.com/1.0/users", Err: retrieveErr})
+	c.Assert(err, check.NotNil)
+	c.Assert(strings.Contains(err.Error(), "session has expired"), check.Equals, true)
+	c.Assert(strings.Contains(err.Error(), "probably down"), check.Equals, false)
+	c.Assert(UnwrapErr(err), check.Equals, retrieveErr)
+}
+
+func (s *S) TestDetectClientErrorGenericStillProbablyDown(c *check.C) {
+	err := detectClientError(&url.Error{Op: "Get", URL: "https://tsuru.example.com/1.0/users", Err: errors.New("connection refused")})
+	c.Assert(err, check.NotNil)
+	c.Assert(strings.Contains(err.Error(), "probably down"), check.Equals, true)
 }


### PR DESCRIPTION
Fixes #268.

Three commits improving error reporting in the OIDC auth flow:

**1. Surface OAuth error redirects during login.** When the IdP redirects
back with an error ([RFC 6749 §4.1.2.1]( https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1)), the callback handler exchanged the
(empty) `code` anyway, so users got the token endpoint's unrelated
`invalid_grant "Code not valid"` instead of the actual authorization error.

Before:
```
Login Failed!
oauth2: "invalid_grant" "Code not valid"
```
After (e.g. misconfigured scopes):
```
Login failed: authorization server returned an error: invalid_request: Invalid scopes: openid
```

The handler now checks `error`/`error_description` (and a missing `code`)
before Exchange, renders the real error on the callback page, and prints it
to stderr so it also lands in the terminal. The `finish` channel handling is
untouched. Exit-code behavior is unchanged (handler errors were already not
propagated — happy to address that separately if wanted).

**2. Report an expired session as such, not "server is probably down".**
`detectClientError` gets a dedicated `*oauth2.RetrieveError` case:

Before:
```
Failed to connect to tsuru server (https://<target>), it's probably down: oauth2: "invalid_grant" "Token is not active"
```
After:
```
your session has expired, please run "tsuru login" (https://<target>): oauth2: "invalid_grant" "Token is not active"
```

The error is wrapped with `errors.Wrapf`, preserving the cause chain that the
re-login retry hook in `main.go` unwraps and matches on (covered by a test
asserting `UnwrapErr` still yields the `*oauth2.RetrieveError`).

**3. Grammar:** "The OIDC token will expiry in %s" → "will expire in %s".

Tests (GoCheck): error-redirect and missing-`code` callbacks (real error on
the page and stderr, token endpoint never called, no token persisted);
`detectClientError` classification for oauth2 errors incl. the unwrap
contract, plus a pin that generic connection errors still say "probably
down"; the existing login test now asserts the corrected message.
