### PR TITLE
Migrate pool list to go-tsuruclient PoolApi

### DIFF
--- a/tsuru/client/pool.go
+++ b/tsuru/client/pool.go
@@ -6,7 +6,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -15,7 +14,7 @@ import (
 
 	"github.com/mitchellh/go-wordwrap"
 	"github.com/spf13/pflag"
-	"github.com/tsuru/go-tsuruclient/pkg/config"
+	"github.com/tsuru/go-tsuruclient/pkg/tsuru"
 	"github.com/tsuru/tablecli"
 	"github.com/tsuru/tsuru-client/tsuru/cmd"
 	"github.com/tsuru/tsuru-client/tsuru/cmd/standards"
@@ -35,16 +34,7 @@ type PoolList struct {
 	json       bool
 }
 
-type Pool struct {
-	Name        string
-	Public      bool
-	Default     bool
-	Provisioner string
-	Allowed     map[string][]string
-	Labels      map[string]string
-}
-
-func (p *Pool) Kind() string {
+func poolKind(p tsuru.Pool) string {
 	if p.Public {
 		return "public"
 	}
@@ -54,23 +44,11 @@ func (p *Pool) Kind() string {
 	return ""
 }
 
-func (p *Pool) GetProvisioner() string {
+func poolProvisioner(p tsuru.Pool) string {
 	if p.Provisioner == "" {
 		return "default"
 	}
 	return p.Provisioner
-}
-
-type poolEntriesList []Pool
-
-func (l poolEntriesList) Len() int      { return len(l) }
-func (l poolEntriesList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
-func (l poolEntriesList) Less(i, j int) bool {
-	cmp := strings.Compare(l[i].Kind(), l[j].Kind())
-	if cmp == 0 {
-		return l[i].Name < l[j].Name
-	}
-	return cmp < 0
 }
 
 func (c *PoolList) Flags() *pflag.FlagSet {
@@ -86,44 +64,42 @@ func (c *PoolList) Flags() *pflag.FlagSet {
 	return c.fs
 }
 
-func (pl *PoolList) Run(context *cmd.Context) error {
-	url, err := config.GetURL("/pools")
+func (pl *PoolList) Run(ctx *cmd.Context) error {
+	apiClient, err := tsuruHTTP.TsuruClientFromEnvironment()
 	if err != nil {
 		return err
 	}
-	request, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := tsuruHTTP.AuthenticatedClient.Do(request)
-	if err != nil {
-		return err
-	}
+	pools, resp, err := apiClient.PoolApi.PoolList(context.TODO())
 	t := tablecli.Table{Headers: tablecli.Row([]string{"Pool", "Kind", "Provisioner", "Teams", "Routers"}), LineSeparator: true}
 	t.TableWriterTruncate = true
-	if resp.StatusCode == http.StatusNoContent {
-		context.Stdout.Write(t.Bytes())
+	if resp != nil && resp.StatusCode == http.StatusNoContent {
+		ctx.Stdout.Write(t.Bytes())
 		return nil
 	}
-	defer resp.Body.Close()
-	var pools []Pool
-	err = json.NewDecoder(resp.Body).Decode(&pools)
 	if err != nil {
 		return err
 	}
-	sort.Sort(poolEntriesList(pools))
+	defer resp.Body.Close()
+
+	sort.Slice(pools, func(i, j int) bool {
+		cmp := strings.Compare(poolKind(pools[i]), poolKind(pools[j]))
+		if cmp == 0 {
+			return pools[i].Name < pools[j].Name
+		}
+		return cmp < 0
+	})
 
 	pools = pl.clientSideFilter(pools)
 
 	if pl.simplified {
 		for _, v := range pools {
-			fmt.Fprintln(context.Stdout, v.Name)
+			fmt.Fprintln(ctx.Stdout, v.Name)
 		}
 		return nil
 	}
 
 	if pl.json {
-		return formatter.JSON(context.Stdout, pools)
+		return formatter.JSON(ctx.Stdout, pools)
 	}
 
 	for _, pool := range pools {
@@ -134,18 +110,18 @@ func (pl *PoolList) Run(context *cmd.Context) error {
 		routers := strings.Join(pool.Allowed["router"], ", ")
 		t.AddRow(tablecli.Row([]string{
 			pool.Name,
-			pool.Kind(),
-			pool.GetProvisioner(),
+			poolKind(pool),
+			poolProvisioner(pool),
 			wordwrap.WrapString(teams, 30),
 			wordwrap.WrapString(routers, 30),
 		}))
 	}
-	context.Stdout.Write(t.Bytes())
+	ctx.Stdout.Write(t.Bytes())
 	return nil
 }
 
-func (c *PoolList) clientSideFilter(pools []Pool) []Pool {
-	result := make([]Pool, 0, len(pools))
+func (c *PoolList) clientSideFilter(pools []tsuru.Pool) []tsuru.Pool {
+	result := make([]tsuru.Pool, 0, len(pools))
 
 	for _, pool := range pools {
 		insert := true
@@ -164,7 +140,6 @@ func (c *PoolList) clientSideFilter(pools []Pool) []Pool {
 
 	return result
 }
-
 func sliceContains(s []string, d string) bool {
 	for _, i := range s {
 		if i == d {

--- a/tsuru/client/pool.go
+++ b/tsuru/client/pool.go
@@ -50,6 +50,7 @@ func (p Pool) GetProvisioner() string {
 	}
 	return p.Provisioner
 }
+
 type PoolList struct {
 	fs         *pflag.FlagSet
 	filter     poolFilter

--- a/tsuru/client/pool.go
+++ b/tsuru/client/pool.go
@@ -41,6 +41,7 @@ type Pool struct {
 	Default     bool
 	Provisioner string
 	Allowed     map[string][]string
+	Labels      map[string]string
 }
 
 func (p *Pool) Kind() string {

--- a/tsuru/client/pool.go
+++ b/tsuru/client/pool.go
@@ -26,29 +26,14 @@ type poolFilter struct {
 	name string
 	team string
 }
-type Pool struct {
-	Name        string
-	Public      bool
-	Default     bool
-	Provisioner string
-	Allowed     map[string][]string
-}
+type Pool tsuru.Pool
 
 func (p Pool) Kind() string {
-	if p.Public {
-		return "public"
-	}
-	if p.Default {
-		return "default"
-	}
-	return ""
+	return poolKind(tsuru.Pool(p))
 }
 
 func (p Pool) GetProvisioner() string {
-	if p.Provisioner == "" {
-		return "default"
-	}
-	return p.Provisioner
+	return poolProvisioner(tsuru.Pool(p))
 }
 
 type PoolList struct {

--- a/tsuru/client/pool.go
+++ b/tsuru/client/pool.go
@@ -26,8 +26,30 @@ type poolFilter struct {
 	name string
 	team string
 }
-type Pool=tsuru.Pool
+type Pool struct {
+	Name        string
+	Public      bool
+	Default     bool
+	Provisioner string
+	Allowed     map[string][]string
+}
 
+func (p Pool) Kind() string {
+	if p.Public {
+		return "public"
+	}
+	if p.Default {
+		return "default"
+	}
+	return ""
+}
+
+func (p Pool) GetProvisioner() string {
+	if p.Provisioner == "" {
+		return "default"
+	}
+	return p.Provisioner
+}
 type PoolList struct {
 	fs         *pflag.FlagSet
 	filter     poolFilter

--- a/tsuru/client/pool.go
+++ b/tsuru/client/pool.go
@@ -26,6 +26,7 @@ type poolFilter struct {
 	name string
 	team string
 }
+type Pool=tsuru.Pool
 
 type PoolList struct {
 	fs         *pflag.FlagSet


### PR DESCRIPTION
fixed I believe, tsuru pool list silently dropped labels during deserialization before fix
Fixes tsuru/tsuru#2909